### PR TITLE
Revert "Update homeassistant/home-assistant Docker tag to v2021.7.1 [ci-skip]"

### DIFF
--- a/cluster/apps/home/home-assistant/release.yaml
+++ b/cluster/apps/home/home-assistant/release.yaml
@@ -16,7 +16,7 @@ spec:
   values:
     image:
       repository: homeassistant/home-assistant
-      tag: 2021.7.1
+      tag: 2021.6.5
     env:
       TZ: America/Chicago
     envFrom:


### PR DESCRIPTION
Reverts zacheryph/k8s-gitops#662