### PR TITLE
Revert "Update Helm release cert-manager to v1.9.1 [ci-skip]"

### DIFF
--- a/cluster/operators/cert-manager/release.yaml
+++ b/cluster/operators/cert-manager/release.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       # registryUrl=https://charts.jetstack.io
       chart: cert-manager
-      version: v1.9.1
+      version: v1.9.0
       sourceRef:
         kind: HelmRepository
         name: jetstack


### PR DESCRIPTION
Reverts zacheryph/k8s-gitops#1531