### PR TITLE
feat(core): add hermes-viewer ServiceAccount for read-only cluster access

### DIFF
--- a/core/hermes-viewer/binding.yaml
+++ b/core/hermes-viewer/binding.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/v1/clusterrolebinding.json
+---
+# Read-only cluster access for the Hermes Agent container (running outside the cluster).
+# Uses the built-in `view` ClusterRole which in k3s >= 1.21 grants get/list/watch on
+# most resources but excludes secrets, RBAC, and pod exec/attach/portforward.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-viewer
+  labels:
+    app.kubernetes.io/name: hermes-viewer
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: homelab-tooling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: hermes-viewer
+    namespace: hermes

--- a/core/hermes-viewer/kustomization.yaml
+++ b/core/hermes-viewer/kustomization.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization.json
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hermes
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - binding.yaml

--- a/core/hermes-viewer/namespace.yaml
+++ b/core/hermes-viewer/namespace.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: homelab-tooling

--- a/core/hermes-viewer/serviceaccount.yaml
+++ b/core/hermes-viewer/serviceaccount.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/serviceaccount.json
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-viewer
+  namespace: hermes
+  labels:
+    app.kubernetes.io/name: hermes-viewer
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: homelab-tooling
+# Tokens are minted on demand via:
+#   kubectl -n hermes create token hermes-viewer --duration=8760h
+# (no Secret is stored in git or in-cluster; this is the modern, secure pattern.)

--- a/core/kustomization.yaml
+++ b/core/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - crossplane.yaml
 - external-snapshotter.yaml
 - hardware.yaml
+- hermes-viewer
 - k8tz.yaml
 - kyverno.yaml
 - longhorn.yaml


### PR DESCRIPTION
## What
Adds a Hermes namespace, a `hermes-viewer` ServiceAccount, and a
ClusterRoleBinding to the built-in `view` role. Lets the Hermes Agent
container (running outside the cluster on the homelab host)
authenticate to the Kubernetes API with read-only access.

## Why
Currently cluster state visibility is limited to local `kubectl` and
the dashboard. A read-only service account enables: node health
polling, pod crash triage, Flux reconciliation status, and PR-driven
flux diff previews.

## Scope (built-in `view` role)
- get / list / watch on most resources
- All Flux CRDs (Kustomization, HelmRelease, OCIRepository, GitRepository, etc.)
- NO secrets, RBAC objects
- NO pod exec, attach, portforward
- NO write operations


## Layout
- `core/hermes-viewer/namespace.yaml` - the `hermes` namespace
- `core/hermes-viewer/serviceaccount.yaml` - the ServiceAccount
- `core/hermes-viewer/binding.yaml` - ClusterRoleBinding -> `view`
- `core/hermes-viewer/kustomization.yaml` - composite
- `core/kustomization.yaml` - picks up the new subdir under existing `core` Kustomization

No new bootstrap entry needed - the existing `core` Kustomization reconciles `./core`.

## After merge
Mint a long-lived token: