### PR TITLE
feat(core): hermes-viewer ServiceAccount for read-only cluster access

### DIFF
--- a/core/hermes-viewer/binding.yaml
+++ b/core/hermes-viewer/binding.yaml
@@ -1,8 +1,10 @@
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/v1/clusterrolebinding.json
 ---
-# Read-only cluster access for the Hermes Agent container (running outside the cluster).
-# Uses the built-in `view` ClusterRole which in k3s >= 1.21 grants get/list/watch on
-# most resources but excludes secrets, RBAC, and pod exec/attach/portforward.
+# Read-only cluster access for the Hermes Agent pod (running inside the
+# cluster, deployed by the `hermes-agent` HelmRelease in this same repo).
+# Uses the built-in `view` ClusterRole which in k3s >= 1.21 grants
+# get/list/watch on most resources but excludes secrets, RBAC, and pod
+# exec/attach/portforward.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,6 +18,10 @@ roleRef:
   kind: ClusterRole
   name: view
 subjects:
+  # Subject namespace must match where the SA actually lives (automation).
+  # The kustomization.yaml's `namespace: automation` directive will also
+  # rewrite this field on apply, but we set it explicitly so the file
+  # is self-documenting.
   - kind: ServiceAccount
     name: hermes-viewer
-    namespace: hermes
+    namespace: automation

--- a/core/hermes-viewer/binding.yaml
+++ b/core/hermes-viewer/binding.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/v1/clusterrolebinding.json
+---
+# Read-only cluster access for the Hermes Agent container (running outside the cluster).
+# Uses the built-in `view` ClusterRole which in k3s >= 1.21 grants get/list/watch on
+# most resources but excludes secrets, RBAC, and pod exec/attach/portforward.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-viewer
+  labels:
+    app.kubernetes.io/name: hermes-viewer
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: homelab-tooling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: hermes-viewer
+    namespace: hermes

--- a/core/hermes-viewer/kustomization.yaml
+++ b/core/hermes-viewer/kustomization.yaml
@@ -2,8 +2,10 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: hermes
+# Pin all resources in this dir to the `automation` namespace so the SA
+# token is co-located with the Hermes pod. ClusterRoleBinding is
+# cluster-scoped and unaffected by this directive.
+namespace: automation
 resources:
-  - namespace.yaml
   - serviceaccount.yaml
   - binding.yaml

--- a/core/hermes-viewer/kustomization.yaml
+++ b/core/hermes-viewer/kustomization.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization.json
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hermes
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - binding.yaml

--- a/core/hermes-viewer/namespace.yaml
+++ b/core/hermes-viewer/namespace.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: homelab-tooling

--- a/core/hermes-viewer/namespace.yaml
+++ b/core/hermes-viewer/namespace.yaml
@@ -1,9 +1,0 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: hermes
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: homelab-tooling

--- a/core/hermes-viewer/serviceaccount.yaml
+++ b/core/hermes-viewer/serviceaccount.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/serviceaccount.json
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-viewer
+  namespace: hermes
+  labels:
+    app.kubernetes.io/name: hermes-viewer
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: homelab-tooling
+# Tokens are minted on demand via:
+#   kubectl -n hermes create token hermes-viewer --duration=8760h
+# (no Secret is stored in git or in-cluster; this is the modern, secure pattern.)

--- a/core/hermes-viewer/serviceaccount.yaml
+++ b/core/hermes-viewer/serviceaccount.yaml
@@ -1,14 +1,22 @@
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/serviceaccount.json
 ---
+# Hermes is deployed into the `automation` namespace, so the SA token must
+# live in the same namespace for the pod to mount it.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hermes-viewer
-  namespace: hermes
+  namespace: automation
   labels:
     app.kubernetes.io/name: hermes-viewer
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: homelab-tooling
-# Tokens are minted on demand via:
-#   kubectl -n hermes create token hermes-viewer --duration=8760h
-# (no Secret is stored in git or in-cluster; this is the modern, secure pattern.)
+# The HelmRelease `services/automation/hermes-agent.yaml` is updated in
+# this same PR to set:
+#   serviceAccount:
+#     name: hermes-viewer
+#     automountServiceAccountToken: true
+# so the pod auto-mounts this SA's token at the standard path
+# (/var/run/secrets/kubernetes.io/serviceaccount/token).
+# From there, Python's kubernetes client can `load_incluster_config()` and
+# talk to the API server with no kubeconfig or long-lived token needed.

--- a/core/kustomization.yaml
+++ b/core/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - crossplane.yaml
 - external-snapshotter.yaml
 - hardware.yaml
+- hermes-viewer
 - k8tz.yaml
 - kyverno.yaml
 - longhorn.yaml

--- a/services/automation/hermes-agent.yaml
+++ b/services/automation/hermes-agent.yaml
@@ -113,3 +113,13 @@ spec:
       limits:
         cpu: "2"
         memory: 4Gi
+
+    # ServiceAccount: use the pre-created `hermes-viewer` SA in this
+    # namespace (see core/hermes-viewer/) and mount its token so the
+    # in-cluster Python kubernetes client can authenticate automatically.
+    # We set `create: false` because the SA is owned by the GitOps repo
+    # (Flux-managed), not the chart.
+    serviceAccount:
+      create: false
+      name: hermes-viewer
+      automountServiceAccountToken: true


### PR DESCRIPTION
## What
Grants the Hermes Agent pod read-only access to the cluster API by:

1. Creating a `hermes-viewer` ServiceAccount in the `automation` namespace
2. Binding it to the built-in `view` ClusterRole
3. Updating the `hermes-agent` HelmRelease to use this SA **and** enable
   `automountServiceAccountToken: true`

That's it. The pod then auto-mounts the SA token at
`/var/run/secrets/kubernetes.io/serviceaccount/token`, and the in-cluster
Python kubernetes client picks it up with `config.load_incluster_config()`.
No kubeconfig, no long-lived token to rotate, no external access.

## Why
This supersedes an earlier approach (long-lived ServiceAccount token +
kubeconfig) once we realized Hermes is deployed in-cluster via
`services/automation/hermes-agent.yaml`. In-cluster config is the
standard, more secure pattern for in-pod workloads.

## Architecture context
- Hermes runs as a pod in the `automation` namespace, deployed by Flux
  via `services/automation/hermes-agent.yaml` (HelmRelease pointing at
  the `ultraworkers/hermes-agent-helm-chart`).
- The chart's default `serviceAccount.automountServiceAccountToken`
  is `false`, so the SA token is currently *not* mounted. This PR
  flips it to `true` and pins the SA name.

## Scope (built-in `view` ClusterRole)
- get / list / watch on most resources
- All Flux CRDs (Kustomization, HelmRelease, OCIRepository, GitRepository, etc.)
- NO secrets, RBAC objects
- NO pod exec, attach, portforward
- NO write operations

## Files
- `core/hermes-viewer/serviceaccount.yaml` (new) - the SA, in `automation`
- `core/hermes-viewer/binding.yaml` (new) - ClusterRoleBinding to `view`
- `core/hermes-viewer/kustomization.yaml` (new) - composite
- `core/kustomization.yaml` (modified) - picks up the new subdir under existing `core` Kustomization
- `services/automation/hermes-agent.yaml` (modified) - adds
  `serviceAccount: { create: false, name: hermes-viewer, automountServiceAccountToken: true }`

No new bootstrap entry needed - the existing `core` Kustomization reconciles `./core`.

## After merge
1. Flux reconciles (~10 min) - the SA + CRB land in-cluster
2. The HelmRelease values change triggers a pod rollout
3. The new pod has the SA token mounted
4. From inside Hermes, `python3 -c "from kubernetes import config, client; config.load_incluster_config(); print(client.CoreV1Api().list_node().items)"` should list nodes

That's the verification step. If `list_node` returns the 3 homelab
nodes, we're good and the k8s integration is live.