### PR TITLE
feat(viewer): extend hermes-viewer to read CNPG/Strimzi/Longhorn CRDs

### DIFF
--- a/core/hermes-viewer/kustomization.yaml
+++ b/core/hermes-viewer/kustomization.yaml
@@ -3,9 +3,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Pin all resources in this dir to the `automation` namespace so the SA
-# token is co-located with the Hermes pod. ClusterRoleBinding is
-# cluster-scoped and unaffected by this directive.
+# token is co-located with the Hermes pod. ClusterRoleBinding and
+# ClusterRole are cluster-scoped and unaffected by this directive.
 namespace: automation
 resources:
   - serviceaccount.yaml
   - binding.yaml
+  - operators-rbac.yaml

--- a/core/hermes-viewer/operators-rbac.yaml
+++ b/core/hermes-viewer/operators-rbac.yaml
@@ -1,0 +1,54 @@
+# Extends the hermes-viewer (read-only) cluster access to include the
+# custom resources for the database / messaging / storage operators
+# installed by this GitOps repo.
+#
+# The built-in `view` ClusterRole bound in `binding.yaml` does NOT
+# cover these CRDs in this cluster — neither the operators' own
+# `*:view` ClusterRoles (which would normally aggregate into `view`)
+# are visible to the SA, so we add an explicit, narrow grant scoped to
+# the three operator groups the k8s health-check cron needs to read.
+#
+# Scope: get / list / watch only. No write verbs. No pod exec. No
+# secrets. The hermes-viewer SA remains read-only cluster-wide.
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/v1/clusterrole.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-viewer-operators-read
+  labels:
+    app.kubernetes.io/name: hermes-viewer
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: homelab-tooling
+rules:
+  # CloudNativePG — Postgres clusters, poolers, backups, scheduled backups
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  # Strimzi — Kafka brokers, topics, users, connectors, MM2, pod sets
+  - apiGroups: ["kafka.strimzi.io", "core.strimzi.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  # Longhorn — volumes, replicas, engines, nodes, instance managers,
+  # settings, recurring jobs, backup targets, snapshots, etc.
+  - apiGroups: ["longhorn.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/v1/clusterrolebinding.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-viewer-operators-read
+  labels:
+    app.kubernetes.io/name: hermes-viewer
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: homelab-tooling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-viewer-operators-read
+subjects:
+  - kind: ServiceAccount
+    name: hermes-viewer
+    namespace: automation


### PR DESCRIPTION
## What
Extends the `hermes-viewer` ServiceAccount's read access to cover the
custom resources for the database, messaging, and storage operators
this repo installs, by adding a second, narrow ClusterRole + binding
alongside the existing one to the built-in `view`.

## Why
The new k8s health-check cron (added in a follow-up) needs to read:
- `postgresql.cnpg.io` — CloudNativePG clusters, poolers, backups, scheduled backups
- `kafka.strimzi.io`, `core.strimzi.io` — Strimzi brokers, topics, users, connectors, MM2, pod sets
- `longhorn.io` — volumes, replicas, engines, nodes, instance managers, settings, recurring jobs

The built-in `view` ClusterRole bound in `binding.yaml` does not cover
these CRDs in this cluster. I confirmed this empirically — the SA
gets `403 Forbidden` listing `clusters.postgresql.cnpg.io`,
`kafkas.kafka.strimzi.io`, and `volumes.longhorn.io`.

## Why a separate, explicit ClusterRole (not binding existing `*:view` roles)
The CNPG, Strimzi, and Longhorn charts each install a `*:view`
ClusterRole that *should* aggregate into the built-in `view` (the
RBAC aggregation feature) — but the `hermes-viewer` SA can't see any
of them with the current `view` binding. Two possible reasons:
1. The aggregation labels aren't set (or are set but conditional).
2. The aggregated `view` ClusterRole doesn't grant list on these
   resources for some other reason (RBAC subject scoping, etc.).

I can't verify which without a SA that can read cluster-scoped RBAC
objects, and `hermes-viewer` is intentionally read-only with no
RBAC-read. Rather than block on that investigation, this PR adds an
explicit, narrow `ClusterRole` (get/list/watch on the three operator
groups only) and binds it to the same SA. Same effective permissions,
no dependency on aggregation correctness, easy to remove if/when the
upstream aggregation is fixed.

## Scope
- `get` / `list` / `watch` only.
- No write verbs, no exec, no secrets, no portforward.
- The SA remains read-only cluster-wide.

## Files
- `core/hermes-viewer/operators-rbac.yaml` (new) — `ClusterRole` + `ClusterRoleBinding`
- `core/hermes-viewer/kustomization.yaml` (modified) — adds the new file to the kustomization

## Verification
- `kubectl kustomize ./core/hermes-viewer/` renders all four resources
  correctly (SA, two CRs, two CRBs).
- After merge, once Flux reconciles, the new ClusterRole + Binding
  will be in the cluster and `hermes-viewer` will be able to read the
  three operator groups.

## Test plan
- [ ] `git pull` (or sync) on this branch
- [ ] Confirm `kubectl kustomize ./core/hermes-viewer/` shows the new `ClusterRole` and `ClusterRoleBinding`
- [ ] After merge, verify in-cluster: `kubectl auth can-i list clusters.postgresql.cnpg.io --as=system:serviceaccount:automation:hermes-viewer` → `yes` (and same for the other two groups)
- [ ] Once unblocked, the health-check cron PR can land
