### PR TITLE
fix(crossplane): bump provider-upjet-digitalocean v0.3.0 -> v0.3.2

### DIFF
--- a/platform/crossplane/providers.yaml
+++ b/platform/crossplane/providers.yaml
@@ -13,7 +13,7 @@ kind: Provider
 metadata:
   name: crossplane-contrib-provider-upjet-digitalocean
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-upjet-digitalocean:v0.3.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-upjet-digitalocean:v0.3.2
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/pkg.crossplane.io/provider_v1.json
 apiVersion: pkg.crossplane.io/v1


### PR DESCRIPTION
## Problem

The `crossplane-contrib-provider-upjet-digitalocean` provider pod in the `crossplane` namespace has been stuck in a 2-minute crash loop (restarts=5067+) since it was installed. The recurring k8s health alert fires every cron cycle with 3 CRIT findings:

- Pod `crossplane-contrib-provider-upjet-digitalocean-86632dae1c0vktl9` — Container `package-runtime` CrashLoopBackOff
- Pod `...` — Container `package-runtime` crashed (3m ago, restart #N)
- Deployment `crossplane-contrib-provider-upjet-digitalocean-86632dae1c06` — 0/1 ready

Plus 2 recurring event WARNs (`SyncPackage: post establish runtime hook failed for package: provider package deployment is unavailable` x3673, `BackOff: Back-off restarting failed container` x22475).

## Root cause

The provider's previous-instance logs show the exact error:

```
provider: error: Cannot start controller manager: failed to wait for
managed/container.digitalocean.crossplane.io/v1alpha1, kind=registries
caches to sync: timed out waiting for cache to be synced for Kind
*v1alpha1.Registries
```

This is **upstream bug** `crossplane-contrib/provider-upjet-digitalocean#81`. Two Terraform resources in the upjet provider both pluralise to `registries`, so `controller-gen` silently overwrote one CRD with the other and the `Registries` v1alpha1 CRD was never emitted into the cluster. The provider's controller-runtime manager tries to start an informer for `Registries` on startup, the watch times out after ~2 minutes, the pod exits, CrashLoopBackOff.

Direct check: `kubectl api-resources | grep -i digitalocean` returns no `managed/container.digitalocean.crossplane.io` resources — CRDs are absent, exactly as the bug report describes.

## Fix

Bump the provider image to **v0.3.2**, which contains the upstream fix (PR #83). v0.3.2 is the smallest possible version bump that fixes the bug; v1.0.0 is a major-version migration to upjet v2 and would be a larger change.

## After merge

Flux will reconcile `platform/crossplane/providers.yaml`, Crossplane will install the v0.3.2 package, the new pod will emit the missing `Registries` CRD on first start, and the 2-minute crash loop will stop. The k8s health check should drop the 3 CRIT + 3 related WARN findings on the next cron run.

## Refs

- [Issue #81 — provider-upjet-digitalocean v0.3.0/v0.3.1 enters restart loop](https://github.com/crossplane-contrib/provider-upjet-digitalocean/issues/81)
- [PR #83 — fix the controller-gen duplicate plural bug](https://github.com/crossplane-contrib/provider-upjet-digitalocean/pull/83)
- [v0.3.2 release notes](https://github.com/crossplane-contrib/provider-upjet-digitalocean/releases/tag/v0.3.2)