### PR TITLE
fix(plex): raise memory limit 2Gi -> 8Gi, add 2Gi request

### DIFF
--- a/services/media/plex.yaml
+++ b/services/media/plex.yaml
@@ -64,11 +64,25 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
             resources:
+              # Plex Media Server's working set routinely exceeds 2 Gi
+              # for any non-trivial library: idle ~500-800 MiB, library
+              # scan 1.5-2.5 GiB transient, 4K transcode 2-3 GiB, plus
+              # a small long-running memory creep. With Intel QuickSync
+              # HW transcode (gpu.intel.com/i915) the frame buffers
+              # count against the cgroup limit, so transcode spikes
+              # push usage above what non-HW Plex needs.
+              #
+              # Observed on the cluster: pod OOMKilled (exit 137)
+              # ~1x/hour over 6 days = 138 restarts. Last OOM
+              # 2026-06-11 09:54:51 UTC. Bump limit 2 Gi -> 8 Gi and
+              # add a 2 Gi request so the scheduler reserves baseline
+              # memory (currently missing).
               requests:
                 cpu: 100m
+                memory: 2Gi
               limits:
                 gpu.intel.com/i915: 1
-                memory: 2Gi
+                memory: 8Gi
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
## Problem

Plex Media Server has been OOMKilled (exit 137) approximately **once per hour** over the last 6 days on this cluster. The pod's lifetime restart count is **138**.

```
Container: app
  Image: sha256:5614ffc8...  (ghcr.io/home-operations/plex:1.43.2.10687)
  Ready: True
  Restarts: 138
  Last terminated: reason=OOMKilled exit=137
    Started: 2026-06-11 09:46:57+00:00
    Finished: 2026-06-11 09:54:51+00:00
```

The pod was also caught as a noisy WARN by the k8s health check (PR #3334) — the new 24h grace window surfaced it for the first time.

## Root cause

The HelmRelease sets a 2 GiB memory limit with **no memory request**. Plex's working set routinely exceeds 2 GiB for any non-trivial library:

| Phase | Working set |
|-------|-------------|
| Idle | ~500–800 MiB |
| Library scan | 1.5–2.5 GiB transient |
| 4K transcode | 2–3 GiB |
| Long-running creep | 0.5–1 GiB over weeks |

The container also requests `gpu.intel.com/i915: 1` for Intel QuickSync HW transcode. GPU frame buffers count against the cgroup memory limit, so transcode sessions push usage above what non-HW Plex would need.

The previous health check only flagged `lifetime_restart_count` ≥ 20 with `phase == "Running"` as a WARN — but the recent-crash CRIT (1h window) had cleared, so the noise was hidden. With PR #3334's new 24h grace window, this is the only pod caught on the cluster that wasn't a known issue.

## Fix

- Raise memory **limit 2 Gi → 8 Gi** (4× headroom for library scans + transcode spikes + creep)
- Add a memory **request of 2 Gi** so the scheduler reserves baseline memory (currently missing — the pod could be packed onto a node that later evicts it under pressure)

If OOMs continue past 8 Gi, the right next move is investigating a potential memory leak in this Plex version (1.43.2.10687) rather than just raising the limit further. The OOMKilled `last_state` detail is captured in the pod's container status and can be re-checked after a few hours with the new limit in effect.

## Diff

```diff
             resources:
+              # Plex Media Server's working set routinely exceeds 2 Gi
+              # for any non-trivial library: ... (full comment in file)
               requests:
                 cpu: 100m
+                memory: 2Gi
               limits:
                 gpu.intel.com/i915: 1
-                memory: 2Gi
+                memory: 8Gi
```