### PR TITLE
fix(monitoring): silence noisy kube-state-metrics liveness 503s

### DIFF
--- a/platform/monitoring/prometheus-stack.yaml
+++ b/platform/monitoring/prometheus-stack.yaml
@@ -104,6 +104,20 @@ spec:
       enabled: true
     kubeStateMetrics:
       enabled: true
+      # Override liveness probe to /healthz.
+      #
+      # The chart default is /livez, which returns 503 when kube-state-metrics
+      # briefly loses contact with the kube-apiserver (logged as
+      # "Failed to contact API server for /livez: got 0" in the container).
+      # These blips do not affect metrics scraping or the pod's ability to
+      # serve /metrics, but they generate noisy 503 events (836 over 13 days
+      # in the June 2026 run). /healthz is the documented process-alive
+      # endpoint and only fails if the HTTP server itself is wedged, which
+      # is the actual condition we want the kubelet to restart on.
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: http
     kubernetesServiceMonitors:
       enabled: true
     kubeApiServer:


### PR DESCRIPTION
## Summary

The `kube-prometheus-stack` chart defaults the `kube-state-metrics` liveness probe to `GET /livez` on the metrics HTTP port. That endpoint returns `503` whenever the pod briefly loses contact with the kube-apiserver — visible in container logs as `Failed to contact API server for /livez: got 0`. The blips are harmless (the pod has been up 13 days without restart, `/metrics` is still being scraped, `/readyz` is unaffected) but generate ~64 noisy 503 events per day that the k8s-health cron keeps alerting on (836 over 13 days on the run that triggered this).

This PR overrides the liveness probe to `GET /healthz`, the documented process-alive endpoint. `/healthz` only fails if the HTTP server itself is wedged, which is the actual condition we want the kubelet to restart on.

## Root cause

`kube-state-metrics`' `/livez` handler calls `cli.HealthzCheck()` on the apiserver client; on a brief blip the client health check fails, the handler writes `503 Internal Server Error`, and the kubelet emits an `Unhealthy` warning event. Because the failures are not three-in-a-row, the pod is never actually restarted, but each individual 503 still produces a k8s event the k8s-health cron treats as a WARN. Switching to `/healthz` decouples the liveness check from apiserver reachability while still catching a wedged or dead process.

## Test plan

- [ ] After Flux applies the change, confirm the rendered Deployment has `livenessProbe.httpGet.path: /healthz`:
  ```bash
  /opt/data/.local/bin/kubectl -n monitoring get deploy kube-prometheus-stack-kube-state-metrics \
    -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}'
  # expect: /healthz
  ```
- [ ] `kubectl -n monitoring rollout status deploy/kube-prometheus-stack-kube-state-metrics`
- [ ] Watch the events for a few minutes; expect no new `Unhealthy: Liveness probe failed` events from this pod:
  ```bash
  /opt/data/.local/bin/kubectl -n monitoring get events \
    --field-selector involvedObject.name=$(/opt/data/.local/bin/kubectl -n monitoring get pod -l app.kubernetes.io/name=kube-state-metrics -o name | head -1 | cut -d/ -f2) \
    --watch
  ```
- [ ] Confirm metrics still scrape (no `up == 0` for the KSM target in Prometheus):
  ```bash
  curl -s https://prometheus.${CLUSTER_DOMAIN}/api/v1/query?query=up{job="kube-state-metrics"} \
    -H "Authorization: Bearer $PROM_TOKEN" | jq '.data.result[0].value[1]'  # expect "1"
  ```
- [ ] Confirm the k8s-health cron no longer reports the KSM liveness 503 finding on the next run.

Auto-generated by k8s-health cron from finding `94bc4510ed272559919268ffde459a8bb44b5773`.
