### PR TITLE
chore(renovate): relabel OCI helm chart commits as chart updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,18 @@
       pinDigests: false,
     },
     {
+      // OCI helm charts are served from docker-style registries, so the flux
+      // manager reports them as "docker tag" updates. Filter on package name
+      // (every OCI helm chart in this repo has "chart" or "-helm" in the path)
+      // and rewrite the commit subject to read as a chart update.
+      description: ["Relabel OCI helm chart commits as chart updates"],
+      matchManagers: ["flux"],
+      matchDatasources: ["docker"],
+      matchPackageNames: ["*chart*", "*-helm*"],
+      commitMessageTopic: "helm chart {{depName}}",
+      commitMessageExtra: "",
+    },
+    {
       description: ["Auto-merge updates to github-action packages"],
       matchManagers: ["github-actions"],
       automerge: true,


### PR DESCRIPTION
## What

Renovate has been opening PRs every day for the 36 OCI helm charts in this repo (cert-manager, crossplane, kube-prometheus-stack, loki, longhorn, metallb, forgejo, etc.), but they all land as `chore(deps): update <oci-url> docker tag to vX.Y.Z` commits. The flux manager treats `OCIRepository.spec.ref.tag` as a docker-style tag, so the docker datasource template kicks in.

This is technically correct — the registry is docker-shaped — but it makes the commit log and dependency dashboard noisy. The 36 chart updates are indistinguishable from container image bumps.

## Fix

Add a single `packageRules` entry that rewrites the commit subject for OCI helm chart packages only. No other behavior changes.

```json5
{
  description: ["Relabel OCI helm chart commits as chart updates"],
  matchManagers: ["flux"],
  matchDatasources: ["docker"],
  matchPackageNames: ["*chart*", "*-helm*"],
  commitMessageTopic: "helm chart {{depName}}",
  commitMessageExtra: "",
}
```

`matchPackageNames: ["*chart*", "*-helm*"]` matches every OCI helm chart depName in the repo (all contain `/charts/`, `/chart/`, `helm-charts`, `charts-mirror`, `-helm`, etc.) and does not match any actual container image (plex, home-assistant, sabnzbd, signal-cli, intel-gpu-plugin, dragonfly, etc.).

## Before / After

**Before**
```
chore(deps): update ghcr.io/cloudnative-pg/charts/cloudnative-pg docker tag to v0.28.3
chore(deps): update quay.io/metallb/chart/metallb docker tag to v0.16.1
chore(deps): update docker.io/envoyproxy/gateway-helm docker tag to v1.8.1
```

**After**
```
chore(deps): update helm chart ghcr.io/cloudnative-pg/charts/cloudnative-pg to v0.28.3
chore(deps): update helm chart quay.io/metallb/chart/metallb to v0.16.1
chore(deps): update helm chart docker.io/envoyproxy/gateway-helm to v1.8.1
```

The dependency dashboard will also show the rule description as a badge on each OCI chart update.

## Scope

- **No effect on container image updates** (the depName filter excludes them).
- **No effect on the minio chart** (the only true `chart.spec.version` style; uses a HelmRepository + `version:` field with the `helm` datasource, not `docker`).
- **No effect on the `pinDigests: false` rule for OCIRepositories** — the new rule is additive and only sets `commitMessageTopic` / `commitMessageExtra`.
- **No effect on existing open PRs** — the new commit subject applies to the next commit on each branch.

## Verification

The new wording will appear on the next OCI chart bump (likely cloudnative-pg, crossplane, longhorn, kube-prometheus-stack, loki, promtail, or metallb). I'll spot-check the first one after merge.
