### PR TITLE
fix(dragonfly): grant configmaps to operator ClusterRole for v1.6.1

### DIFF
--- a/core/operators/dragonfly.yaml
+++ b/core/operators/dragonfly.yaml
@@ -102,7 +102,7 @@ spec:
             resources: ["events"]
             verbs: ["create", "patch"]
           - apiGroups: [""]
-            resources: ["pods", "services"]
+            resources: ["configmaps", "pods", "services"]
             verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
           - apiGroups: [""]
             resources: ["pods/status"]


### PR DESCRIPTION
## Summary
Dragonfly operator (`operators-system/dragonfly-operator`) is in CrashLoopBackOff
(restarts=10, deployment 0/1 ready) since ~2026-06-13 02:38 UTC. Root cause is a
missing RBAC rule that the v1.6.1 image requires. This PR adds `configmaps` to the
existing core API group in the chart-installed ClusterRole.

## Root cause
- Renovate bumped `ghcr.io/dragonflydb/operator` from v1.5.0 to v1.6.1 in commit
  59015bda (2026-06-12 20:01 UTC).
- Upstream v1.6.1 added a watch on `*v1.ConfigMap` to the `Dragonfly` controller
  (see upstream `config/rbac/role.yaml` at the `v1.6.1` tag — `configmaps` is now
  listed alongside `pods` and `services`).
- The gitops `rbac.roles.dragonfly-operator.rules` were not updated. The operator
  process therefore logged
  `configmaps is forbidden: User "system:serviceaccount:operators-system:dragonfly-operator" cannot list resource "configmaps" in API group "" at the cluster scope`
  on every retry. The ConfigMap informer cache never synced, so after the
  2-minute default cache-sync timeout the manager logged
  `failed to wait for *v1.ConfigMap caches to sync: timed out waiting for cache to be synced`
  and exited 1. Other EventSources (NetworkPolicy, Pod, Service, StatefulSet,
  Dragonfly CRD) appeared to fail too, but those are downstream — once the
  manager entered its stop sequence, the in-flight cache-sync timeouts for
  other kinds fired as the manager tore down. The ConfigMap RBAC is the
  proximate cause.

The downstream `Dragonfly` CR (`services/immich/dragonfly.yaml`) is currently
unmanaged and the immich deployment is operating without its in-cluster
Dragonfly cache.

## Fix
Add `configmaps` to the existing core API group rule that already covers
`pods` and `services`. One-line change; matches upstream v1.6.1 ClusterRole
verbatim.

## Test plan
- [ ] `flux -n flux-system reconcile hr dragonfly-operator` to force reconcile
- [ ] `kubectl -n operators-system rollout status deploy/dragonfly-operator` (should reach 1/1 ready within ~1 min)
- [ ] `kubectl -n operators-system logs deploy/dragonfly-operator --tail=200 | grep -i "configmap\|forbidden\|cache"` (no forbidden / cache-sync errors)
- [ ] `kubectl -n operators-system get pods` shows the dragonfly-operator pod with 0 restarts
- [ ] `kubectl -n immich get dragonfly` shows the existing Dragonfly CR is now reconciled

Auto-generated by k8s-health cron from finding b2ea161885546a802adfe2310e11ccfd00228e82.
