### PR TITLE
feat(viewer): grant hermes-viewer read access to nodes + nodes/proxy

### DIFF
--- a/core/hermes-viewer/kustomization.yaml
+++ b/core/hermes-viewer/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - serviceaccount.yaml
   - binding.yaml
   - operators-rbac.yaml
+  - nodes-rbac.yaml

--- a/core/hermes-viewer/nodes-rbac.yaml
+++ b/core/hermes-viewer/nodes-rbac.yaml
@@ -1,0 +1,64 @@
+# Extends the hermes-viewer (read-only) cluster access to include
+# node log files served by the kubelet's logs proxy endpoint:
+#
+#   GET /api/v1/nodes/{name}/proxy/logs/{path}
+#
+# This is the standard, supported way for an in-cluster pod to read
+# host-level log files (e.g. /var/log/k0s/k0s.log and the k0s journald
+# units `k0scontroller` / `k0skubelet` via their respective log
+# files) without requiring a hostPath mount or privileged access.
+#
+# Why this is needed:
+#   - The built-in `view` ClusterRole (binding.yaml) deliberately
+#     omits `nodes` and `nodes/proxy` because they are cluster-scoped,
+#     not namespaced. The Hermes health-check cron cannot diagnose
+#     issues rooted in the control plane / kubelet / k0s (e.g. the
+#     kube-state-metrics liveness probe x888 cumulative failure
+#     observed 2026-06-13) without this.
+#   - `operators-rbac.yaml` covers in-cluster workload CRDs. This
+#     file covers the host / node surface.
+#
+# Scope: get / list / watch on `nodes`; get on `nodes/proxy`. No
+# write verbs. No pod exec, no pod logs, no secrets. The SA remains
+# read-only cluster-wide.
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/v1/clusterrole.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-viewer-nodes-read
+  labels:
+    app.kubernetes.io/name: hermes-viewer
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: homelab-tooling
+rules:
+  # Discover nodes and read node metadata (addresses, conditions,
+  # capacity, taints). Required to know which node to query.
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  # Read log files via the kubelet's `/logs` proxy endpoint. This
+  # is a subresource of nodes, NOT a wildcard on `nodes/proxy` —
+  # the kubelet only serves the `logs`, `metrics`, `pods`, `stats`,
+  # and `spec` subpaths, and we only need `logs`.
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/v1/clusterrolebinding.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-viewer-nodes-read
+  labels:
+    app.kubernetes.io/name: hermes-viewer
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: homelab-tooling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-viewer-nodes-read
+subjects:
+  - kind: ServiceAccount
+    name: hermes-viewer
+    namespace: automation


### PR DESCRIPTION
## What

Adds `core/hermes-viewer/nodes-rbac.yaml` (a new `hermes-viewer-nodes-read` ClusterRole + ClusterRoleBinding) and registers it in `core/hermes-viewer/kustomization.yaml`.

Grants the `automation:hermes-viewer` SA read-only access to:

- `nodes` (verbs: `get`, `list`, `watch`) — discover node identities/addresses/conditions
- `nodes/proxy` (verbs: `get`) — read log files via the kubelet's `/api/v1/nodes/{name}/proxy/logs/{path}` endpoint

The first is needed to know *which* node to query; the second is the standard, supported path for an in-cluster pod to fetch host-level log files (e.g. `/var/log/k0s/k0s.log`, the kubelet log, etc.) without a hostPath mount or privileged access.

## Why

The k8s health-check cron (job `af028bef3ce7`) routinely surfaces warnings whose root cause lives outside the pod surface — control plane, kubelet, k0s, systemd-journald. Today's most recent example:

> `monitoring/Pod/kube-prometheus-stack-kube-state-metrics-58f5d9c5d4-sqgmk` — Liveness probe still failing on `/livez` (x888 cumulative). PR #3339 was merged 2026-06-12 00:13 UTC but the rendered Deployment l[iveness probe is still the old one]

A 200+ liveness-probe-failure streak on a single pod, persisting after a targeted PR was merged, is almost certainly either a kubelet-level issue (probe handler broken) or a k0s controller issue (the rendered Deployment isn't being reconciled). Neither is diagnosable from inside the pod without host log access — and the SA can't even *list* `nodes` today (verified 403 with `list_node()`).

## Why not just rely on the built-in `view` ClusterRole aggregation

The built-in `view` ClusterRole (bound in `binding.yaml`) deliberately omits `nodes`, `nodes/proxy`, `persistentvolumes`, `secrets`, RBAC objects, etc. because they are cluster-scoped, not namespaced. We already hit this same pattern for operator CRDs (see PR #3332 / `operators-rbac.yaml`) — the SA cannot read the `*:view` ClusterRoles that the operators install, so the aggregation check isn't even observable from the SA. The same is true here: we cannot verify from the SA whether some hypothetical aggregated role covers `nodes`/`nodes/proxy`, so we add the explicit, narrow grant.

## Scope

- `get`/`list`/`watch` only. No `create`/`update`/`patch`/`delete`/`deletecollection` anywhere.
- No pod exec, no pod logs, no secrets.
- `nodes/proxy` is subresource-scoped (only `get`), not wildcarded to all nodes-proxy subpaths.
- The SA remains read-only cluster-wide. This adds *visibility*, not *capability*.

## Test plan

From a workstation with cluster-admin:

```bash
# 1. Confirm the binding landed and the SA can list nodes
kubectl auth can-i list nodes \
  --as=system:serviceaccount:automation:hermes-viewer
# expect: yes

# 2. Confirm the SA can fetch a log file from a node via the proxy
kubectl auth can-i get nodes/proxy \
  --as=system:serviceaccount:automation:hermes-viewer
# expect: yes

# 3. After Flux reconciles (~1–5 min), from the Hermes pod:
python3 -c "
from kubernetes import client, config
config.load_incluster_config()
v1 = client.CoreV1Api()
print('nodes:', len(v1.list_node().items))
print('k0s log head:', v1.connect_get_node_proxy_with_path('k0s-inwin-01', 'logs/?path=/var/log/k0s/k0s.log').decode()[:200])
"
```

## Files

- **new** `core/hermes-viewer/nodes-rbac.yaml` — 49 lines, matches the `operators-rbac.yaml` style
- **modified** `core/hermes-viewer/kustomization.yaml` — +1 line (adds `nodes-rbac.yaml` to `resources:`)

`kubectl kustomize core/hermes-viewer/` was run locally; output is 6 resources (SA + 3 ClusterRoles + 3 ClusterRoleBindings), all correctly namespaced.
