### PR TITLE
fix(monitoring): actually patch kube-state-metrics liveness probe to /healthz

### DIFF
--- a/platform/monitoring/prometheus-stack.yaml
+++ b/platform/monitoring/prometheus-stack.yaml
@@ -29,6 +29,26 @@ spec:
     kind: OCIRepository
     name: kube-prometheus-stack
   interval: 1h
+
+  # Patch the rendered Deployment for kube-state-metrics to use /healthz
+  # for the liveness probe instead of the chart-default /livez. See the
+  # `kubeStateMetrics:` block below for the full root-cause writeup; the
+  # short version is that the kube-state-metrics subchart hardcodes the
+  # liveness probe path as a string literal, so values-level overrides
+  # of livenessProbe.httpGet.path are silently ignored. A kustomize
+  # strategic-merge patch on the post-rendered manifest is the only
+  # way to change it without forking the chart.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: kube-prometheus-stack-kube-state-metrics
+            patch: |
+              - op: replace
+                path: /spec/template/spec/containers/0/livenessProbe/httpGet/path
+                value: /healthz
+
   values:
     cleanPrometheusOperatorObjectNames: true
 
@@ -104,20 +124,42 @@ spec:
       enabled: true
     kubeStateMetrics:
       enabled: true
-      # Override liveness probe to /healthz.
+      # NOTE: do NOT try to override livenessProbe.httpGet.path here. The
+      # kube-state-metrics subchart (v7.4.0, shipped with kube-prometheus-stack
+      # 86.2.2) hardcodes the liveness probe path as a string literal in
+      # `charts/kube-state-metrics/templates/deployment.yaml`:
       #
-      # The chart default is /livez, which returns 503 when kube-state-metrics
-      # briefly loses contact with the kube-apiserver (logged as
-      # "Failed to contact API server for /livez: got 0" in the container).
-      # These blips do not affect metrics scraping or the pod's ability to
-      # serve /metrics, but they generate noisy 503 events (836 over 13 days
-      # in the June 2026 run). /healthz is the documented process-alive
-      # endpoint and only fails if the HTTP server itself is wedged, which
-      # is the actual condition we want the kubelet to restart on.
-      livenessProbe:
-        httpGet:
-          path: /healthz
-          port: http
+      #   livenessProbe:
+      #     httpGet:
+      #       ...
+      #       path: /livez          # ← not a template expression, not overridable
+      #       port: http
+      #       ...
+      #
+      # Only `failureThreshold`, `httpGet.scheme`, `httpGet.httpHeaders`,
+      # `initialDelaySeconds`, `periodSeconds`, `successThreshold`, and
+      # `timeoutSeconds` are read from .Values.livenessProbe. A values-level
+      # `livenessProbe: { httpGet: { path: /healthz } }` is silently ignored.
+      #
+      # The actual fix is a Flux `postRenderers` kustomize patch (see
+      # `spec.postRenderers` above) that replaces the path in the rendered
+      # Deployment manifest. PR #3339 added the values-level override on
+      # 2026-06-12; the rendered Deployment was never actually changed, the
+      # pod was never rolled, and the noise continued.
+      #
+      # Root cause of the underlying problem: kube-state-metrics's `/livez`
+      # handler calls `cli.HealthzCheck()` on its in-cluster apiserver client
+      # and returns 503 if the apiserver's own `/livez` blips. The k0s
+      # kube-apiserver in this cluster returns empty responses (~got 0~)
+      # intermittently (visible in the pod's container log as
+      # ~Failed to contact API server for /livez: got 0~). These blips do
+      # not affect `/metrics` scraping or the pod's actual health, but
+      # produce one `Unhealthy: Liveness probe failed: HTTP probe failed
+      # with statuscode: 503` event per blip, which the k8s-health cron
+      # surfaces as a WARN. The proper fix is to point KSM's liveness
+      # probe at `/healthz` (the documented process-alive endpoint that
+      # only fails if the HTTP server itself is wedged) — which is what
+      # the postRender patch above does.
     kubernetesServiceMonitors:
       enabled: true
     kubeApiServer:


### PR DESCRIPTION
## What

Adds a Flux `HelmRelease.spec.postRenderers[].kustomize.patches[]` block on `monitoring/kube-prometheus-stack` that patches the rendered kube-state-metrics Deployment's `livenessProbe.httpGet.path` from `/livez` to `/healthz`. Replaces the (non-functional) values-level `kubeStateMetrics.livenessProbe.httpGet.path: /healthz` override from PR #3339 with a long inline comment explaining why that approach can't work.

Verified end-to-end locally: rendered the chart with `helm template`, applied the postRender kustomize, and confirmed the patch flips the path. `kubectl kustomize` of the rendered manifest + the patch returns the Deployment with `livenessProbe.httpGet.path: /healthz`.

## Why

The k8s-health cron has been flagging the kube-state-metrics pod for ~14 days with `Unhealthy: Liveness probe failed: HTTP probe failed with statuscode: 503` (x888 cumulative). PR #3339 (merged 2026-06-12 00:13 UTC) was supposed to silence this by changing the probe to `/healthz`. The rendered Deployment's liveness probe today still points at `/livez`:

```
liveness_probe: http_get: {path: '/livez', port: 'http', scheme: 'HTTP'}
```

…and the kube-state-metrics pod is still on the same ReplicaSet it was created in on 2026-05-30 (`kube-prometheus-stack-kube-state-metrics-58f5d9c5d4`, container running since `2026-05-30 01:38:07`, restart_count=0). The PR's fix was never actually applied.

### Root cause: the chart hardcodes the liveness probe path

The kube-state-metrics subchart (v7.4.0, shipped with kube-prometheus-stack 86.2.2) renders the Deployment from `charts/kube-state-metrics/templates/deployment.yaml`. That template has:

```yaml
livenessProbe:
  failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
  httpGet:
    ...
    path: /livez          # ← literal string, not .Values.livenessProbe.httpGet.path
    port: http             # ← literal string, not .Values.livenessProbe.httpGet.port
    ...
    scheme: {{ upper .Values.livenessProbe.httpGet.scheme }}
```

Only `failureThreshold`, `httpGet.scheme`, `httpGet.httpHeaders`, `initialDelaySeconds`, `periodSeconds`, `successThreshold`, and `timeoutSeconds` are pulled from `.Values.livenessProbe`. `path` and `port` are hardcoded string literals. A values-level override of `livenessProbe: { httpGet: { path: /healthz } }` is silently dropped on the floor.

I confirmed this by:

1. Downloading the chart tgz from the OCI registry (`ghcr.io/prometheus-community/charts/kube-prometheus-stack:86.2.2`).
2. Reading the subchart template at `charts/kube-state-metrics/templates/deployment.yaml`.
3. Rendering the full chart with our actual values and inspecting the output: the rendered `livenessProbe.httpGet.path` is `/livez`, not `/healthz`.

### Underlying problem (why `/livez` was returning 503 in the first place)

KSM's `/livez` handler calls `cli.HealthzCheck()` on its in-cluster apiserver client and returns 503 if the apiserver's own `/livez` blips. The k0s kube-apiserver in this cluster returns empty responses intermittently — visible in the pod's container log (every blip) as:

```
W0613 HH:MM:SS  server.go:556] Failed to contact API server for /livez: got 0
```

…which is the KSM client getting a 0-byte response from the apiserver. These blips are not actionable from the GitOps repo (would need ssh/exec on the k0s controller to diagnose the apiserver side), and they don't affect `/metrics` scraping or the pod's actual health. They DO produce one `Unhealthy: Liveness probe failed: HTTP probe failed with statuscode: 503` k8s event per blip, which is what the k8s-health cron surfaces as a WARN.

The proper fix is to point KSM's liveness probe at `/healthz`, the documented process-alive endpoint that only fails if the HTTP server itself is wedged — the actual condition we want the kubelet to restart on.

## How (the postRender pattern)

```yaml
spec:
  postRenderers:
    - kustomize:
        patches:
          - target:
              kind: Deployment
              name: kube-prometheus-stack-kube-state-metrics
            patch: |
              - op: replace
                path: /spec/template/spec/containers/0/livenessProbe/httpGet/path
                value: /healthz
```

This is the standard Flux v2.2+ pattern for "Helm doesn't expose this knob" situations. The patch runs against the rendered manifests after `helm template` produces them, before Flux applies them to the cluster. The target is the rendered Deployment name (which uses the Helm release name as a prefix: `kube-prometheus-stack-kube-state-metrics`, NOT the values-level path `kubeStateMetrics`).

JSON 6902 (`- op: replace ...`) was used because the chart hardcodes the path — a strategic-merge patch would have to specify the entire `livenessProbe` object, which would lose all the chart's other defaults (failureThreshold, periodSeconds, etc.) unless merged carefully. The single-field replace is surgical.

## Verification

End-to-end local check (ran on the Hermes pod, log saved):

```python
# 1. Render the chart with our actual values
helm template kube-prometheus-stack oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack \
  --version 86.2.2 -f values.yaml -n monitoring
# → kube-state-metrics Deployment rendered with livenessProbe.httpGet.path = /livez

# 2. Apply the postRender kustomize patch
kubectl kustomize /path/to/postrender/kustomization/
# → kube-state-metrics Deployment rendered with livenessProbe.httpGet.path = /healthz
```

After merging this PR and waiting for Flux to reconcile (~1–5 min):

```bash
# From a workstation, confirm the rendered Deployment:
kubectl get deploy -n monitoring kube-prometheus-stack-kube-state-metrics \
  -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}'
# expect: /healthz

# The kube-state-metrics pod should be rolled (new ReplicaSet, new container
# start time, new pod-template-hash). Container log should NOT contain
# 'Failed to contact API server for /livez: got 0' after the roll.

# The k8s-health cron's WARN for this pod should clear on the next run.
```

## Files

- **modified** `platform/monitoring/prometheus-stack.yaml` — net +55 / -13 lines:
  - Adds `spec.postRenderers` block with the inline kustomize patch
  - Removes the dead `kubeStateMetrics.livenessProbe` values override
  - Replaces the short "override liveness probe" comment with a ~30-line note documenting the hardcoded-path bug, the values-level override being silently ignored, and the underlying apiserver-`/livez` root cause — so a future maintainer doesn't reintroduce the broken override

## Related

- PR #3339 — the original (broken) values-level override, now superseded
- PR #3332 — granted hermes-viewer read access to operator CRDs (the read path that let us diagnose this one)
- PR #3345 — granted hermes-viewer read access to `nodes` + `nodes/proxy`, enabling host log fetches via the kubelet proxy (used in the diagnosis)
- Skill `hermes-k8s-incluster` — the read-only patterns used throughout
