### PR TITLE
feat(monitoring): add kube-apiserver 5xx alert + document kubeEtcd k0s gap

### DIFF
--- a/platform/monitoring/monitors/kube-apiserver.yaml
+++ b/platform/monitoring/monitors/kube-apiserver.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+---
+# Early-warning alert for kube-apiserver 5xx rate, per-instance.
+#
+# Background: on 2026-06-13, the k8s-health-check cron surfaced a stale
+# KSM liveness-probe 503 (finding #4) that had been firing since 2026-05-30.
+# Investigation found that the 503 was *itself* the canary for a real
+# underlying problem — the kube-apiserver on k0s-inwin-01 was returning
+# 5xx at 0.088% of requests (10x the rate of the other two apiservers),
+# with lease PUT p50 of 3.5s vs 25-56ms elsewhere. The cluster had
+# ~989k cumulative 5xx from that single instance over 14 days, but
+# no alert fired because nothing in the default kube-prometheus-stack
+# ruleset watches apiserver_request_total by-instance.
+#
+# This rule fires when any single apiserver's 5xx rate exceeds
+# ~0.6 errors/min sustained for 5 minutes. WATCH errors are excluded
+# because they're a different signal (long-lived stream reconnect blips
+# usually self-recover and are not actionable on their own).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-apiserver-errors
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: kube-apiserver-errors
+    app.kubernetes.io/part-of: monitoring
+    app.kubernetes.io/component: alerts
+spec:
+  groups:
+    - name: kube-apiserver.errors
+      interval: 1m
+      rules:
+        - alert: KubeAPIServerHigh5xxRate
+          # Threshold: 0.01 5xx/s per apiserver instance for 5m.
+          # At 30 rps steady-state that's a 0.03% error rate, well
+          # above the 0.005-0.014% baseline of the healthy nodes
+          # in this cluster. Tune if too noisy in practice.
+          expr: |
+            sum by (instance) (
+              rate(apiserver_request_total{code=~"5..",verb!="WATCH"}[5m])
+            ) > 0.01
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "kube-apiserver {{ $labels.instance }}: 5xx rate {{ $value | humanize }}/s"
+            description: |
+              kube-apiserver instance {{ $labels.instance }} is returning 5xx
+              responses at {{ $value | humanize }} requests/sec sustained for
+              5+ minutes. WATCH errors are excluded.
+
+              Diagnostic queries (run from a host with `kubectl` access):
+
+                # Per-verb 5xx breakdown for this instance:
+                sum by (verb, resource) (
+                  rate(apiserver_request_total{code=~"5..",instance="{{ $labels.instance }}",verb!="WATCH"}[5m])
+                )
+
+                # Apiserver self-reported request duration p99 for this instance:
+                histogram_quantile(0.99,
+                  sum by (le) (rate(apiserver_request_duration_seconds_bucket{instance="{{ $labels.instance }}"}[5m]))
+                )
+
+                # If the slowness is lease/coordination bound, check etcd-side
+                # latency as seen by the apiserver's own client:
+                histogram_quantile(0.99,
+                  sum by (le, operation) (
+                    rate(apiserver_etcd_request_duration_seconds_bucket{instance="{{ $labels.instance }}"}[5m])
+                  )
+                )
+
+              If the failing instance is a known-bad node (e.g. a slow disk
+              or a flapping apiserver process), drain it with
+              `kubectl drain <node> --ignore-daemonsets` and let the
+              remaining apiservers take over while you investigate.

--- a/platform/monitoring/monitors/kustomization.yaml
+++ b/platform/monitoring/monitors/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
 # - cert-manager.yaml
 - flux-system.yaml
+- kube-apiserver.yaml

--- a/platform/monitoring/prometheus-stack.yaml
+++ b/platform/monitoring/prometheus-stack.yaml
@@ -98,6 +98,38 @@ spec:
       enabled: true
     kubeDns:
       enabled: false
+    # kubeEtcd.enabled=true deploys a chart-default ServiceMonitor that
+    # selects `app.kubernetes.io/name: kube-etcd`, but the chart's
+    # auto-created Service has no matching pods in k0s (k0s runs etcd
+    # as part of the k0s controller process, listening on each
+    # controller's local interface — not as a Pod, and not exposed as
+    # a normal in-cluster Service). The default ServiceMonitor
+    # therefore has 0 targets and exposes no etcd server-side metrics.
+    #
+    # What we *do* have, today, is client-side etcd request duration:
+    # the apiserver exposes its own client-go etcd client metrics on
+    # its /metrics endpoint, which is scraped by the
+    # `kubeApiServer.enabled: true` job below (job label: `apiserver`).
+    # That's how queries like
+    # `apiserver_request_total{...resource="leases"...}` get their
+    # data, and it's the dataset the kube-apiserver-errors PrometheusRule
+    # in `platform/monitoring/monitors/kube-apiserver.yaml` alerts on.
+    #
+    # To get etcd *server-side* metrics (etcd_disk_wal_fsync_duration_seconds,
+    # etcd_server_leader_changes_seen_total, etcd_server_is_leader,
+    # etcd_mvcc_db_total_size_in_bytes, etc.) a k0s-specific config
+    # is needed:
+    #   1. A headless Service + Endpoints pointing at the k0s
+    #      controller nodes' etcd listener (10.72.13.11/12/13:2379).
+    #   2. A custom ServiceMonitor that scrapes those endpoints with
+    #      TLS to the k0s-generated etcd CA (read from
+    #      /var/lib/k0s/etcd/ca.crt on a controller and seeded into
+    #      a Secret).
+    #   3. Disable the chart's default ServiceMonitor
+    #      (`kubeEtcd.serviceMonitor.enabled: false`) so it doesn't
+    #      fight the new one.
+    # Tracked as a follow-up; the kube-apiserver-errors rule covers
+    # the user-visible signal in the meantime.
     kubeEtcd:
       enabled: true
     kubeProxy:


### PR DESCRIPTION
feat(monitoring): add kube-apiserver 5xx alert + document kubeEtcd k0s gap

Adds an early-warning PrometheusRule that fires when any single
kube-apiserver's 5xx rate exceeds ~0.6 errors/min for 5 minutes.
WATCH errors are excluded — they're a different signal
(long-lived stream reconnect blips, usually self-recovered, not
actionable on their own).

Motivating context: the 2026-06-13 KSM liveness-probe
investigation found that the kube-apiserver on k0s-inwin-01 had
been returning 5xx at 0.088% of requests for 14 days straight
(989k cumulative errors, 10x the other two apiservers, with
lease PUT p50 of 3.5s vs 25-56ms elsewhere). No alert in the
default kube-prometheus-stack ruleset watches
apiserver_request_total by instance, so this went unsignalled
until the KSM /livez canary tripped. This rule is the missing
per-instance signal: it would have fired on the same 0.0222/s
peak that surfaced in the manual query.

Also documents the kubeEtcd ServiceMonitor situation in
prometheus-stack.yaml: the chart's default ServiceMonitor is a
no-op in k0s (the chart's auto-created Service has no matching
pods because k0s runs etcd as part of the controller process,
not as a pod). The chart subkey stays enabled so future
config can layer on top, and the comment explains what's needed
for a real k0s-specific etcd server-side metric scrape (headless
Service + Endpoints + custom ServiceMonitor + k0s etcd CA
Secret). The current apiserver-side client metrics under
job=apiserver cover the user-visible signal in the meantime,
which is what the new rule alerts on.

Files:
  - platform/monitoring/monitors/kube-apiserver.yaml (new):
    PrometheusRule with one alert (KubeAPIServerHigh5xxRate)
  - platform/monitoring/monitors/kustomization.yaml: include it
  - platform/monitoring/prometheus-stack.yaml: comment block on
    kubeEtcd explaining the k0s gap and the path to a proper
    etcd server-side metric scrape
