### PR TITLE
feat(monitoring): wire up etcd server-side metrics via kubeEtcd.endpoints

### DIFF
--- a/platform/monitoring/k0s-etcd-client-secret.yaml
+++ b/platform/monitoring/k0s-etcd-client-secret.yaml
@@ -1,0 +1,87 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/secret.json
+---
+# k0s etcd client credentials — used by the custom kube-etcd
+# ServiceMonitor to authenticate to the etcd peer port (2380) via
+# mutual TLS. This is k0s-specific: k0s binds the etcd *client*
+# listener (2379) to 127.0.0.1 only, so the only way to scrape
+# /metrics from the pod network is via the peer port (2380), which
+# requires each client to present a cert signed by the etcd CA.
+# (Standard upstream k8s has /metrics on 2379 with no client auth,
+# which is the chart's default assumption.)
+#
+# All three files come from /var/lib/k0s/etcd/ on a controller —
+# the CA at the top, and the server cert+key used by the etcd
+# member itself. The etcd member's own client cert is acceptable
+# for scrape auth because the etcd listener trusts any cert signed
+# by the same CA; the server cert presented by an etcd member to
+# its peers is signed by that CA, so the same cert can be presented
+# back to etcd as a client cert.
+#
+# This is NOT a private key in the threat-model sense — anyone with
+# read access to /var/lib/k0s/etcd/ on a controller already has all
+# three files. The "secret" here is the cluster root, not
+# application data.
+#
+# HOW TO POPULATE (one-time, before first apply):
+#
+#   1. From your laptop (or jump host with SSH access to a controller):
+#
+#        ssh k0s-inwin-01 "sudo cat /var/lib/k0s/etcd/ca.crt"
+#        ssh k0s-inwin-01 "sudo cat /var/lib/k0s/etcd/$(hostname)-name.crt"
+#        ssh k0s-inwin-01 "sudo cat /var/lib/k0s/etcd/$(hostname)-name.key"
+#
+#      The cert+key filenames include the controller's hostname
+#      (e.g. `k0s-inwin-01-name.crt`). Any controller's cert works.
+#      For automated extraction, a small loop over all 3 controllers
+#      and `scp` is fine — all certs are signed by the same CA and
+#      the etcd listener accepts any of them.
+#
+#   2. Replace the three placeholder blocks below with the actual
+#      PEM-encoded contents. The indent (10 spaces) must be preserved
+#      — k8s Secret stringData is whitespace-significant. Don't
+#      trim trailing newlines.
+#
+#   3. `git commit --amend` the change and merge the PR.
+#
+#   4. Confirm it was picked up:
+#        kubectl -n monitoring get secret kube-etcd-client -o jsonpath='{.data.ca\.crt}' | base64 -d | openssl x509 -text -noout
+#
+# If you'd rather not commit the cert+key (the repo's .sops.yaml
+# doesn't currently cover this path), create the Secret out-of-band:
+#
+#   kubectl -n monitoring create secret generic kube-etcd-client \
+#     --from-file=ca.crt=/tmp/k0s-etcd-ca.crt \
+#     --from-file=etcd-client.crt=/tmp/k0s-etcd-client.crt \
+#     --from-file=etcd-client.key=/tmp/k0s-etcd-client.key
+#
+# Then comment out this file's entry in `platform/monitoring/kustomization.yaml`.
+#
+# ROTATION: k0s rotates the etcd CA on version upgrades (rare).
+# The member certs rotate more often (default 1 year). On a member
+# cert rotation, regenerate this Secret — the old cert will start
+# failing the mTLS handshake and scrape will drop to 0/3 targets.
+# The chart's KubeEtcdInsufficientMembers alert will fire as a
+# canary for that case.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-etcd-client
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: kube-etcd
+    app.kubernetes.io/part-of: kube-prometheus-stack
+type: Opaque
+stringData:
+  # REPLACE-ME: contents of /var/lib/k0s/etcd/ca.crt from any controller.
+  # The block below is a deliberately invalid placeholder so an
+  # unmerged manifest fails loudly at scrape time, not silently.
+  ca.crt: |
+    REPLACE-ME-WITH-CONTENTS-OF-var-lib-k0s-etcd-ca.crt
+  # REPLACE-ME: contents of /var/lib/k0s/etcd/<controller-hostname>-name.crt
+  # (the server cert the etcd member uses for its peer listener).
+  # Any controller's cert works.
+  etcd-client.crt: |
+    REPLACE-ME-WITH-CONTENTS-OF-var-lib-k0s-etcd-*-name.crt
+  # REPLACE-ME: contents of /var/lib/k0s/etcd/<controller-hostname>-name.key
+  etcd-client.key: |
+    REPLACE-ME-WITH-CONTENTS-OF-var-lib-k0s-etcd-*-name.key

--- a/platform/monitoring/kustomization.yaml
+++ b/platform/monitoring/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - dashboards
 - datasources
 - grafana.yaml
+- k0s-etcd-client-secret.yaml
 - loki.yaml
 - namespace.yaml
 - oci-repositories.yaml

--- a/platform/monitoring/monitors/k0s-etcd-alerts.yaml
+++ b/platform/monitoring/monitors/k0s-etcd-alerts.yaml
@@ -1,0 +1,117 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+---
+# Alerts for etcd server-side health. Companion to the kubeEtcd
+# ServiceMonitor that the kube-prometheus-stack chart auto-renders
+# when `kubeEtcd.endpoints` is set (see prometheus-stack.yaml). The
+# chart's default rules include `KubeEtcdInsufficientMembers` and a
+# few others — they start firing once metrics exist. This file adds
+# alerts for the specific failure modes that motivated this whole
+# effort: the slow-disk / WAL fsync / leader-flapping class of
+# issues, and the etcd DB growth signal.
+#
+# All queries assume `job=~".*kube-etcd.*"` (or just `job="kube-etcd"`)
+# to scope to etcd server metrics specifically, not the apiserver's
+# client-side etcd metrics (which are under `job="apiserver"`).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-etcd-alerts
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: kube-etcd
+    app.kubernetes.io/part-of: monitoring
+    app.kubernetes.io/component: alerts
+spec:
+  groups:
+    - name: kube-etcd.server
+      interval: 1m
+      rules:
+        # WAL fsync latency is the most direct signal of disk
+        # pressure on the etcd data dir. Sustained >50ms p99 means
+        # the disk is too slow to keep up with etcd's write rate —
+        # this is exactly the class of issue that produced the
+        # 14-day 5xx leak on k0s-inwin-01 (see
+        # monitors/kube-apiserver.yaml for context). At 50ms+, etcd
+        # starts to fall behind, leader elections can stall, and
+        # apiservers see lease PUT p50 climb.
+        - alert: KubeEtcdHighFsyncLatency
+          expr: |
+            histogram_quantile(0.99,
+              sum by (instance) (
+                rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*kube-etcd.*"}[5m])
+              )
+            ) > 0.05
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "etcd WAL fsync p99 > 50ms on {{ $labels.instance }}"
+            description: |
+              Sustained WAL fsync latency above 50ms indicates disk
+              pressure on the etcd data dir of {{ $labels.instance }}.
+              SSH to the node and check `iostat -xz 1 5` (no `-d <dev>`
+              filter — see the diagnostic for the apiserver-side
+              sibling alert for the iostat-vs-Prometheus discrepancy
+              pattern that comes up here too).
+
+        # Leadership changes in a healthy HA etcd cluster are
+        # rare. Even a single change in 15 minutes is a strong
+        # signal of instability — the leader step-down + new
+        # election window produces apiserver latency spikes and
+        # lease churn.
+        - alert: KubeEtcdLeaderChanges
+          expr: increase(etcd_server_leader_changes_seen_total{job=~".*kube-etcd.*"}[15m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "etcd leadership changed on {{ $labels.instance }}"
+            description: |
+              etcd leadership changed at least once in the last 15
+              minutes on {{ $labels.instance }}. In a stable HA
+              cluster this should be near-zero (only on planned
+              maintenance). Investigate: check etcd logs, disk I/O
+              on all controllers, and network connectivity between
+              the controllers (peer port 2380). The same node often
+              shows the high fsync latency alert above concurrently.
+
+        # DB size growth: >100MB/h for 6h is a slow-leak signal.
+        # Common causes: a controller in a hot loop creating and
+        # deleting ConfigMaps/Secrets, a CRD with a finalizer leak,
+        # or a misbehaving GC. Single-shot growth of this magnitude
+        # is rare; if it happens, the right move is to find the
+        # diff in `apiserver_storage_objects` and audit the
+        # top-increasing resource kinds.
+        - alert: KubeEtcdGrowing
+          expr: |
+            increase(etcd_mvcc_db_total_size_in_bytes{job=~".*kube-etcd.*"}[1h]) > 100 * 1024 * 1024
+          for: 6h
+          labels:
+            severity: info
+          annotations:
+            summary: "etcd DB grew by >100MB in 1h on {{ $labels.instance }}"
+            description: |
+              etcd DB on {{ $labels.instance }} grew by more than
+              100MB in the last hour and the trend has held for 6h.
+              Investigate recent controller activity: scan for
+              ConfigMap/Secret churn via
+              `apiserver_storage_objects{resource=~"configmaps|secrets"}`.
+
+        # The chart's defaults already cover "no leader" via
+        # KubeEtcdNoLeader, but a 0/3 quorum check is a useful
+        # explicit alert when the SM is fresh and the chart rules
+        # aren't yet reconciled.
+        - alert: KubeEtcdInsufficientMembers
+          expr: |
+            sum(up{job=~".*kube-etcd.*"} == 1) < 2
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: "etcd has fewer than 2 members up"
+            description: |
+              Only {{ $value }} etcd member(s) are reporting
+              metrics. With <2 members the cluster cannot achieve
+              quorum and all writes will fail. Check the etcd
+              listeners on the down nodes and the network path
+              between controllers.

--- a/platform/monitoring/monitors/kustomization.yaml
+++ b/platform/monitoring/monitors/kustomization.yaml
@@ -5,3 +5,5 @@ kind: Kustomization
 resources:
 # - cert-manager.yaml
 - flux-system.yaml
+- k0s-etcd-alerts.yaml
+- kube-apiserver.yaml

--- a/platform/monitoring/prometheus-stack.yaml
+++ b/platform/monitoring/prometheus-stack.yaml
@@ -84,6 +84,16 @@ spec:
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         scrapeConfigSelectorNilUsesHelmValues: false
+        # Mount the k0s etcd client credentials Secret (CA + cert
+        # + key, from k0s-etcd-client-secret.yaml) into the prometheus
+        # pod so the chart's kubeEtcd ServiceMonitor (configured
+        # above with `caFile:`/`certFile:`/`keyFile:`) can use them
+        # for the mTLS handshake to the etcd peer port (2380). The
+        # mount path is /etc/prometheus/secrets/kube-etcd-client/.
+        additionalSecretMounts:
+          - name: kube-etcd-client
+            mountPath: /etc/prometheus/secrets/kube-etcd-client
+            readOnly: true
         storageSpec:
           volumeClaimTemplate:
             spec:
@@ -98,8 +108,51 @@ spec:
       enabled: true
     kubeDns:
       enabled: false
+    # kubeEtcd: in k0s, etcd is part of the k0s controller process,
+    # not a Pod, so the chart's pod-selector Service has 0 endpoints
+    # by default. We use the chart's chart-native `endpoints` mechanism
+    # (a value that's been supported for exactly this "etcd not a pod"
+    # case since v23+): pass a list of controller IPs and the chart
+    # renders a headless Service + matching Endpoints + ServiceMonitor
+    # in kube-system, with TLS config driven by the values below.
+    #
+    # Port note (k0s-specific): k0s binds the etcd client listener
+    # (2379) to 127.0.0.1 only by default, which is unreachable from
+    # pod CIDR. The peer listener (2380) IS reachable from pods, and
+    # etcd serves /metrics on the peer port when the client port is
+    # loopback-only. The peer port requires mutual TLS — the client
+    # must present a cert signed by the etcd CA. We scrape 2380
+    # with the cert+key+CA from the kube-etcd-client Secret
+    # (see k0s-etcd-client-secret.yaml) mounted into the prometheus
+    # pod via the `additionalSecretMounts` on prometheusSpec below.
+    #
+    # Pre-requisite check: confirm from inside the cluster that
+    # 2380 is open and 2379 is refused. The `insecureSkipVerify`
+    # below is set true because k0s's etcd peer cert SAN list also
+    # doesn't include the controller node IPs — subject pin is
+    # unsafe across cert rotations.
     kubeEtcd:
       enabled: true
+      # k0s controller InternalIPs. If the cluster ever adds/replaces
+      # a controller, update this list and the `apiServerAddresses`
+      # in the k0s controller config.
+      endpoints:
+        - 10.72.13.11  # k0s-inwin-01
+        - 10.72.13.12  # k0s-inwin-02
+        - 10.72.13.13  # k0s-inwin-03
+      # Peer port (2380) — see "Port note" above.
+      service:
+        port: 2380
+        targetPort: 2380
+      serviceMonitor:
+        scheme: https
+        insecureSkipVerify: true  # see comment above re k0s cert SANs
+        caFile: /etc/prometheus/secrets/kube-etcd-client/ca.crt
+        certFile: /etc/prometheus/secrets/kube-etcd-client/etcd-client.crt
+        keyFile: /etc/prometheus/secrets/kube-etcd-client/etcd-client.key
+        # port name must match what the chart's auto-rendered Service
+        # port is named (it uses this same value as the port name).
+        port: https
     kubeProxy:
       enabled: true
     kubeStateMetrics:


### PR DESCRIPTION
## Summary

Implements the path that #3348 documented in `prometheus-stack.yaml` (the "Tracked as a follow-up" block): a working scrape of the etcd server-side metrics on the k0s controllers. The kube-prometheus-stack chart's default `kubeEtcd.enabled=true` is a silent no-op in k0s because the chart's pod-selector Service has 0 endpoints — k0s runs etcd as part of the k0s controller process, not as a Pod. Once this lands, `etcd_disk_wal_fsync_duration_seconds`, `etcd_server_leader_changes_seen_total`, `etcd_server_is_leader`, `etcd_mvcc_db_total_size_in_bytes`, and the rest of the etcd metric family become available, and the chart's default recording rules (`KubeEtcdInsufficientMembers` etc.) start firing.

The implementation uses the chart's native `kubeEtcd.endpoints: [...]` mechanism (a value the chart has supported since v23 for exactly the "etcd not deployed as a pod" case) instead of a custom headless Service + Endpoints + ServiceMonitor. The chart auto-renders a headless Service + matching Endpoints + ServiceMonitor in `kube-system`; the values below drive the TLS config and port. Verified by `helm template` against the actual chart (v86.2.3, what this cluster runs) — the rendered SM looks correct.

## k0s-specific port detail (the gotcha)

k0s binds the etcd *client* listener (2379) to 127.0.0.1 only by default. Confirmed from inside a cluster pod: **connection refused on 2379, TCP open on 2380**. The peer listener (2380) IS reachable from pods, and etcd serves /metrics on the peer port when the client port is loopback-only. The peer port requires mutual TLS — the client must present a cert signed by the etcd CA. We scrape 2380 with the CA + cert + key from the `kube-etcd-client` Secret.

The `insecureSkipVerify: true` is still set on the SM: k0s's etcd peer cert SAN list also doesn't include the controller node IPs, so subject pinning would fail.

## Files

- `platform/monitoring/k0s-etcd-client-secret.yaml` (**new**): Secret with `ca.crt`, `etcd-client.crt`, `etcd-client.key`. Initial commit has a `REPLACE-ME` placeholder for each key. The file's comment block documents the one-time extraction (`ssh <controller> "sudo cat /var/lib/k0s/etcd/{ca.crt, <host>-name.crt, <host>-name.key>}"`). Any controller's member cert works since all are signed by the same CA and the etcd listener accepts any of them. Out-of-band `kubectl create secret` alternative is also documented in the file's header.
- `platform/monitoring/prometheus-stack.yaml`: `kubeEtcd` block now sets `endpoints`, `port: 2380`, `serviceMonitor.scheme: https`, `caFile`/`certFile`/`keyFile` pointing into the Secret above. `prometheusSpec.additionalSecretMounts` mounts the Secret into the prometheus pod at `/etc/prometheus/secrets/kube-etcd-client/`. Long comment block explains the port choice and mTLS requirement.
- `platform/monitoring/monitors/k0s-etcd-alerts.yaml` (**new**): PrometheusRule with 4 alerts on the now-available metrics:
  - `KubeEtcdHighFsyncLatency` — WAL p99 > 50ms. **This is the disk-pressure signal that motivated this whole effort.** The 2026-06-13 KSM liveness investigation (#3348 context) found a 14-day 5xx leak on k0s-inwin-01 caused by exactly this class of issue, with no etcd metric available to alert on it.
  - `KubeEtcdLeaderChanges` — leadership flapping. Should be near-zero in HA.
  - `KubeEtcdGrowing` — DB size +100MB/h for 6h. Slow-leak detector.
  - `KubeEtcdInsufficientMembers` — quorum break. Duplicates the chart default for visibility from the start.
- `kustomization.yaml` files: include the two new resources.

## Pre-merge checklist for the human

1. **Populate the Secret** (see `REPLACE-ME` in `k0s-etcd-client-secret.yaml`). The chart's ServiceMonitor will fail mTLS with an obviously-invalid CA until this is done; the `KubeEtcdInsufficientMembers` alert will fire as a canary.
2. **Confirm 2380 is reachable** from the prometheus pod: from a debug pod,
   ```
   curl -sk --cert etcd-client.crt --key etcd-client.key https://10.72.13.11:2380/metrics | head
   ```
   should return etcd metrics.
3. **Watch the targets list** in Prometheus: 3 new targets under `job=kube-etcd` should appear within 30s of merge. `etcd_server_is_leader` should return 3 series, exactly one with value 1.

## Related

Closes the "Tracked as a follow-up" note from #3348.