### PR TITLE
feat(obsidian): run obsidian-headless as a sidecar in the hermes pod

### DIFF
--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -120,10 +120,12 @@ stringData:
     OIDC_VELERO_UI_CLIENT_SECRET: ENC[AES256_GCM,data:RvNU96cIK1xrKA+NFm5rPanOhRwXnQrCPK7OvmVwxW4=,iv:4DbkfSB5h0BNYeMhSTrRicsc1CJ8cwDTZ0YPfU+IqVg=,tag:huAPL1gwssAOdg9W2KyWTQ==,type:str]
     VELERO_UI_ADMIN_PASSWORD: ENC[AES256_GCM,data:N7WBIAetjidGaJYgwULUGgcUcPTqDY5tMtc+tHAGPc4=,iv:xnM/yPu4BURAGST74Q3P7g66lrI9PBnkeNN1UxitlNE=,tag:yeibmtwivuabwfYinhAwMw==,type:str]
     VELERO_UI_PASSPHRASE: ENC[AES256_GCM,data:oUHMhd1k2aU6dgfKR7ua5baUKXB9ei6f9v5w31wwWvp6Tyz6kQhEhriHzrCQQipNQHGmxwTY2GUMCJj98TFntg==,iv:4LUjUdnG3gOVbmhYxAIxki5W4HuU2pSXItEblI5hS/Y=,tag:FV4RczXYKXVoq9ZvP/esHA==,type:str]
+    HERMES_OBSIDIAN_AUTH_TOKEN: ENC[AES256_GCM,data:PqnnUhme06Eq8nnJ32AK5c8+pCsP0ebFp2Bk2NsZ65Y=,iv:5hp2ZWRU6Lig0H3w0S9pwyaCCqt0kYWCe+Wzi15QvJI=,tag:e92ySyrqkpsNV5RX9tcUMg==,type:str]
+    HERMES_OBSIDIAN_VAULT_NAME: ENC[AES256_GCM,data:FFSrxQ==,iv:4Zm0Fm0k7xC+UcKgWSAENVuC/bJukbLvK+j6VRFnK2Y=,tag:b/n+bV26YlUt45i5woykgA==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-28T07:06:40Z"
-    mac: ENC[AES256_GCM,data:KpO5bxaOt6JGjh7R48Sq+4gTVWNw6c4EPevdrh4WVAxkd93kL0bb08d3SwQ8sdE6nMMlZrrS6HzqecdECjKZe11Wm84mUzURT3pivRzymOx2+B73UDuh7gzFU8r+R0jVlFZWiKYet7fN9nMPIwx6BM4p14xK+FE34arvqxG1Sl0=,iv:+O1lfcqd0MNR9WrOLD4qAl56QTM88vVVsj1REKlkWxo=,tag:c5jm7PAcJ7LtT7p/s95X/A==,type:str]
+    lastmodified: "2026-07-02T04:28:26Z"
+    mac: ENC[AES256_GCM,data:zj6NDcnMyCYSkPTH7O1YUtuv0uD1L7/l2k6UB+Ks+3idAszH2uvfm2EeH7NPlAkpTYUL4omWf8+YXm+St9Hftbj7KL7HcVOCh2K6gYNcEu9a0jhJ8yNfKwxj4n5AqMLim6tNfQ8pkOecdfHoS9wWYEMZQRu5b33IaGwU1clFdlE=,iv:3uDqnVjGSnT99UOvL7WEzc7U+khQcN/nwERXijYuWcw=,tag:aRvK4EgaMagvcqWWHH9y4w==,type:str]
     pgp:
         - created_at: "2026-06-08T03:22:24Z"
           enc: |-

--- a/services/automation/hermes-agent.yaml
+++ b/services/automation/hermes-agent.yaml
@@ -1,4 +1,12 @@
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: obsidian-auth-token
+type: Opaque
+stringData:
+  auth_token: ${HERMES_OBSIDIAN_AUTH_TOKEN}
+---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/gitrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
@@ -187,7 +195,7 @@ spec:
           port: api-server
         initialDelaySeconds: 10
         periodSeconds: 5
-        failureThreshold: 30   # up to 150s for cold start
+        failureThreshold: 30 # up to 150s for cold start
       liveness:
         httpGet:
           path: /health

--- a/services/automation/hermes-agent.yaml
+++ b/services/automation/hermes-agent.yaml
@@ -217,3 +217,154 @@ spec:
       create: false
       name: hermes-viewer
       automountServiceAccountToken: true
+
+    # --- Obsidian sync sidecar ---
+    # Runs obsidian-headless as a sidecar in the Hermes pod to mirror
+    # /opt/data/Obsidian <-> Obsidian Sync in real time. Non-secret
+    # configuration (vault name) is in cluster-secrets. The auth token
+    # is in the `obsidian-auth-token` Secret (created out-of-band via
+    # `kubectl create secret generic` — see the PR description for the
+    # runbook). The obsidian skill uses OBSIDIAN_VAULT_PATH=/opt/data/Obsidian.
+    extraVolumes:
+      - name: obsidian-auth
+        secret:
+          secretName: obsidian-auth-token
+          defaultMode: 0o600
+      - name: obsidian-config
+        emptyDir: {}
+    extraInitContainers:
+      - name: obsidian-sync-init
+        image: node:22-bookworm-slim
+        imagePullPolicy: IfNotPresent
+        command: [/bin/sh, -ec]
+        args:
+          - |
+            set -eu
+            # Install obsidian-headless into a persistent location on the
+            # shared data PVC. The install survives pod restarts because
+            # /opt/obsidian-headless is a subPath of the data PVC.
+            if [ ! -x /opt/obsidian-headless/bin/ob ]; then
+              mkdir -p /opt/obsidian-headless
+              npm install --prefix /opt/obsidian-headless --global \
+                "obsidian-headless@${OBSIDIAN_HEADLESS_VERSION}"
+            fi
+            # Bind the local vault path to the remote Obsidian vault.
+            # `ob sync-setup` is idempotent — re-running with the same args
+            # is a no-op, so the || true keeps this resilient.
+            /opt/obsidian-headless/bin/ob sync-setup \
+              --vault "${HERMES_OBSIDIAN_VAULT_NAME}" \
+              --path /opt/data/Obsidian \
+              --device-name hermes-server \
+              || true
+            # Apply sync options. `--conflict-strategy conflict` keeps both
+            # copies on collision (safer than `merge` for markdown).
+            /opt/obsidian-headless/bin/ob sync-config \
+              --path /opt/data/Obsidian \
+              --mode bidirectional \
+              --conflict-strategy conflict \
+              --file-types image,audio,video,pdf,unsupported \
+              --configs appearance,hotkey,core-plugin,community-plugin
+            echo "obsidian-sync-init: complete"
+        env:
+          - name: HOME
+            value: /var/lib/obsidian
+          - name: NPM_CONFIG_PREFIX
+            value: /opt/obsidian-headless
+          - name: NPM_CONFIG_CACHE
+            value: /var/lib/obsidian/.npm
+          - name: OBSIDIAN_HEADLESS_VERSION
+            value: "0.0.11"
+          - name: HERMES_OBSIDIAN_VAULT_NAME
+            value: ${HERMES_OBSIDIAN_VAULT_NAME}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 0
+          runAsNonRoot: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: data
+            mountPath: /opt/data/Obsidian
+            subPath: Obsidian
+          - name: data
+            mountPath: /opt/obsidian-headless
+            subPath: obsidian-headless
+          - name: obsidian-config
+            mountPath: /var/lib/obsidian
+          - name: tmp
+            mountPath: /tmp
+    extraContainers:
+      - name: obsidian-sync
+        image: node:22-bookworm-slim
+        imagePullPolicy: IfNotPresent
+        command: [/bin/sh, -ec]
+        args:
+          - |
+            set -eu
+            # Re-install obsidian-headless if /opt/obsidian-headless is
+            # missing (e.g. first start, or PVC was wiped). The install
+            # lives on the data PVC so this is normally a no-op.
+            if [ ! -x /opt/obsidian-headless/bin/ob ]; then
+              mkdir -p /opt/obsidian-headless
+              npm install --prefix /opt/obsidian-headless --global \
+                "obsidian-headless@${OBSIDIAN_HEADLESS_VERSION}"
+            fi
+            # Supervisor loop — restart on any non-zero exit. k8s
+            # restartPolicy handles pod-level restarts; this handles
+            # process-level restarts within the same pod.
+            while true; do
+              echo "[$(date -Iseconds)] starting ob sync --continuous" \
+                | tee -a /var/lib/obsidian/sync.log
+              /opt/obsidian-headless/bin/ob sync \
+                --path /opt/data/Obsidian --continuous \
+                2>&1 | tee -a /var/lib/obsidian/sync.log
+              echo "[$(date -Iseconds)] ob sync exited rc=${PIPESTATUS[0]}, restarting in 5s" \
+                | tee -a /var/lib/obsidian/sync.log
+              sleep 5
+            done
+        env:
+          - name: HOME
+            value: /var/lib/obsidian
+          - name: NPM_CONFIG_PREFIX
+            value: /opt/obsidian-headless
+          - name: NPM_CONFIG_CACHE
+            value: /var/lib/obsidian/.npm
+          - name: OBSIDIAN_HEADLESS_VERSION
+            value: "0.0.11"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 384Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 0
+          runAsNonRoot: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: data
+            mountPath: /opt/data/Obsidian
+            subPath: Obsidian
+          - name: data
+            mountPath: /opt/obsidian-headless
+            subPath: obsidian-headless
+          - name: obsidian-config
+            mountPath: /var/lib/obsidian
+          - name: obsidian-auth
+            mountPath: /var/lib/obsidian/.config/obsidian-headless/auth_token
+            subPath: auth_token
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp


### PR DESCRIPTION
## Summary

Adds an `obsidian-sync` sidecar to the Hermes pod that runs `obsidian-headless` against `/opt/data/Obsidian` (a subPath on the existing data PVC). The Mac keeps using Obsidian desktop with Sync enabled; both clients are different devices on the same vault.

The chart already supports `extraInitContainers`, `extraContainers`, and `extraVolumes` (see `templates/deployment.yaml` line 285), so no chart changes are needed.

## Why a sidecar (not a nohup supervisor in the Hermes container)

- **Resource isolation:** sidecar has its own 50m/128Mi requests, 200m/384Mi limits. Sync bursts (initial pull, attachment syncs) don't compete with the agent.
- **Process isolation:** if `ob sync` crashes, only the sidecar restarts. Hermes is unaffected.
- **Security boundary:** the auth-token Secret is mounted only into the sidecar; the Hermes container's filesystem never sees it.
- **Lifecycle isolation:** init container runs `ob sync-setup` / `ob sync-config` once; main sidecar runs the sync loop. k8s `restartPolicy: Always` handles pod-level restarts.

## What's in this PR

- `services/automation/hermes-agent.yaml` — adds `extraInitContainers` (`obsidian-sync-init`), `extraContainers` (`obsidian-sync`), and `extraVolumes` (`obsidian-auth`, `obsidian-config`) to the Flux `HelmRelease` values. Both new containers use `node:22-bookworm-slim`, run as root to match the data PVC ownership, with `readOnlyRootFilesystem: true` and `capabilities.drop: [ALL]`.
- The auth-token Secret (`obsidian-auth-token` in the `automation` namespace) is created **out-of-band** via `kubectl create secret generic`. See the runbook below.

## Runbook — first-time setup after merge

1. **Mac:** subscribe to Obsidian Sync and set up the vault (Settings → Sync). Note the exact vault name.
2. **Mac:** log in once to generate the auth token:
   ```bash
   npm install -g obsidian-headless
   ob login    # Apple ID + password + 2FA
   cat ~/.config/obsidian-headless/auth_token
   ```
3. **Server:** decrypt `config/secrets.yaml`, add the vault name, re-encrypt, commit:
   ```bash
   sops -d config/secrets.yaml > /tmp/secrets.yaml
   # add to stringData.cluster-secrets:
   #   HERMES_OBSIDIAN_VAULT_NAME: Your Vault Name
   sops -e -i config/secrets.yaml
   git add config/secrets.yaml && git commit -m "feat(obsidian): add HERMES_OBSIDIAN_VAULT_NAME"
   ```
4. **Cluster:** create the auth-token Secret (substitute the path to the Mac's `auth_token` file, scp'd or pasted to the server):
   ```bash
   kubectl -n automation create secret generic obsidian-auth-token      --from-file=auth_token=/path/to/auth_token
   ```
5. **Gateway:** add to `~/.hermes/.env` and restart:
   ```
   OBSIDIAN_VAULT_PATH=/opt/data/Obsidian
   ```
6. **Verify:**
   ```bash
   kubectl -n automation get pods -l app.kubernetes.io/name=hermes-agent
   # 1/1 Running, 2/2 Ready (hermes-agent + obsidian-sync), 0/1 Completed (obsidian-sync-init)

   kubectl -n automation logs -l app.kubernetes.io/name=hermes-agent -c obsidian-sync --tail=20
   # "starting ob sync --continuous" and recent activity

   ls /opt/data/Obsidian | head    # top-level vault entries
   ```
7. **Smoke test:** in a Hermes session, `read_file(path="/opt/data/Obsidian/<known-note>.md")` should return content. Create a note via `write_file` and confirm it appears in Obsidian on the Mac within 30 s.

## Followups (out of scope for this PR)

- The auth-token Secret could be moved into the git repo under SOPS for reproducibility. Skipped for v1 to keep the one-time setup simple.
- Promoting the sidecar to a separate Deployment would require an RWX PVC (Longhorn shared or NFS). Skipped; the sidecar-in-same-pod model handles restart isolation well enough at this scale.

## Related

- Plan v3: `.hermes/plans/2026-06-15_120000-obsidian-vault-server-access-v3-sidecar.md` (supersedes v2 in-pod supervisor plan)
