### PR TITLE
feat(dns): split-DNS with BIND + ExternalDNS (RFC 2136)

### DIFF
--- a/platform/dns/README.md
+++ b/platform/dns/README.md
@@ -1,0 +1,185 @@
+# Split-DNS Automation (BIND + ExternalDNS)
+
+Two ExternalDNS deployments push records to Cloudflare (public) and an
+in-cluster BIND server (internal). OPNSense forwards the zone to BIND so
+LAN clients get local answers while the internet sees Cloudflare.
+
+## Components
+
+- **bind** — BIND 9 Deployment (hand-rolled, single replica). Acts as an
+  authoritative nameserver for the public zone on the internal side.
+  ExternalDNS writes A/AAAA/CNAME records via RFC 2136 (TSIG-signed).
+  Backed by a Longhorn PVC for zone journal persistence. Exposed via
+  MetalLB LoadBalancer at `10.72.16.51`.
+- **external-dns-cloudflare** — bitnami/external-dns HelmRelease with
+  `provider=cloudflare`. Pushes records to the Cloudflare API.
+- **external-dns-rfc2136** — bitnami/external-dns HelmRelease with
+  `provider=rfc2136`. Pushes records to the in-cluster BIND server via
+  TSIG-signed dynamic DNS updates.
+
+## Architecture
+
+```
+HTTPRoute ──► ExternalDNS-cloudflare ──► Cloudflare API     (public)
+Service LB ┘
+HTTPRoute ──► ExternalDNS-rfc2136   ──► BIND (RFC 2136)    (internal)
+Service LB ┘                              │
+                                          │ MetalLB LB IP 10.72.16.51
+                                          │
+                                    OPNSense Unbound (forward-zone)
+                                          ▲
+                                    LAN clients
+```
+
+## Source of truth
+
+A record appears in both providers when:
+
+- An HTTPRoute has a `spec.hostnames` entry under the public zone, OR
+- A Service of type LoadBalancer has the annotation
+  `external-dns.alpha.kubernetes.io/hostname: <name>.<zone>`.
+
+To exclude a resource, set the annotation
+`external-dns.alpha.kubernetes.io/enabled: "false"`.
+
+## Secrets (one-time out-of-band)
+
+### Cloudflare API token
+
+1. In the Cloudflare dashboard, create an API token with:
+   - **Permissions:** `Zone:DNS:Edit`
+   - **Zone Resources:** Include → Specific zone → `<zone>`
+2. Find the zone ID:
+   ```bash
+   curl -s -H "Authorization: Bearer *** \
+     https://api.cloudflare.com/client/v4/zones | jq '.result[] | select(.name=="<zone>") | .id'
+   ```
+3. Replace `REPLACE_WITH_CLOUDFLARE_ZONE_ID` in
+   `platform/dns/external-dns-cloudflare.yaml`.
+4. Create the Secret in-cluster:
+   ```bash
+   kubectl -n dns create secret generic cloudflare-api-token \
+     --from-literal=api-token='<token from step 1>'
+   ```
+
+### RFC 2136 TSIG key for BIND
+
+The TSIG key hardcoded in `bind.yaml` (ConfigMap `bind-config`) and in the
+Secret `rfc2136-tsig` must match. If you want a new key:
+
+```bash
+# Generate a fresh TSIG key
+tsig-keygen -a hmac-sha256 external-dns.
+# Output looks like:
+# key "external-dns." {
+#     algorithm hmac-sha256;
+#     secret "BASE64_SECRET_HERE";
+# };
+
+# Update the key in bind.yaml (ConfigMap -> bind-config -> named.conf)
+# AND update the Secret:
+kubectl -n dns create secret generic rfc2136-tsig \
+  --from-literal=tsig-secret='BASE64_SECRET_HERE' \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The `external-dns-rfc2136` HelmRelease references this secret by name
+(`rfc2136.existingSecret: rfc2136-tsig`).
+
+## OPNSense configuration (follow-up, not in this PR)
+
+In the OPNSense UI:
+
+1. **Services → Unbound DNS → Overrides → Domain Overrides**
+2. Click **Add**
+3. **Domain:** `<public zone>`
+4. **Type:** "Forward"
+5. **IP Address:** `10.72.16.51` (the MetalLB IP of the `bind` service)
+6. Click **Save**, then **Apply**.
+
+After this, queries for `<public zone>` from LAN clients go
+OPNSense → in-cluster BIND → answer. External queries hit Cloudflare.
+
+## Verification (end-to-end)
+
+Run after merge:
+
+```bash
+# 1. Confirm everything in the dns namespace is healthy
+kubectl -n dns get pods
+# Expected: bind-* (1/1), external-dns-rfc2136-* (1/1),
+#           external-dns-cloudflare-* (1/1) — all Running
+
+# 2. Confirm BIND is reachable via the MetalLB IP
+kubectl -n dns run digtest --rm -it --image=mirror.gcr.io/busybox:1.36 -- \
+  dig +short ns1.example.com @10.72.16.51
+# Expected: 10.72.16.51 (the seed NS record)
+
+# 3. Create a test HTTPRoute
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: extdns-smoketest
+  namespace: default
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+  hostnames: ["smoketest.example.com"]
+  rules:
+    - backendRefs:
+        - name: kube-dns
+          port: 53
+EOF
+
+# 4. Wait ~90s for ExternalDNS to reconcile
+sleep 90
+
+# 5. Verify in BIND (via RFC 2136)
+kubectl -n dns run digtest2 --rm -it --image=mirror.gcr.io/busybox:1.36 -- \
+  dig +short smoketest.example.com @10.72.16.51
+# Expected: the gateway LB IP
+
+kubectl -n dns exec deploy/bind -- named-checkzone example.com /var/bind/data/example.com.zone
+# Should show the zone with the new smoketest record
+
+# 6. Verify in Cloudflare
+# (replace <zone id> with the actual zone ID)
+curl -s -H "Authorization: Bearer *** \
+  "https://api.cloudflare.com/client/v4/zones/<zone id>/dns_records" | \
+  jq '.result[] | select(.name=="smoketest.example.com")'
+# Expected: a record with name "smoketest.example.com"
+
+# 7. From a LAN client (after OPNSense config):
+dig +short smoketest.example.com
+# Expected: the gateway LB IP (via OPNSense → BIND)
+
+# 8. Cleanup
+kubectl delete -n default httproute extdns-smoketest
+sleep 90
+# Records disappear from BIND and Cloudflare.
+```
+
+## Troubleshooting
+
+- **BIND pod won't start** — check the init container logs:
+  `kubectl -n dns logs bind-* -c seed-zone`. If the seed zone copy fails,
+  the PVC may not be writable. Verify Longhorn is healthy.
+- **ExternalDNS can't reach BIND** — verify the service resolves from
+  inside the cluster: `kubectl -n dns run digtest --rm -it --image=busybox -- nslookup bind.dns.svc.cluster.local`
+- **TSIG signature errors in ExternalDNS logs** — the TSIG key in the
+  Secret (`rfc2136-tsig`) doesn't match the key in BIND's ConfigMap
+  (`bind-config`). Regenerate both and re-deploy.
+- **OPNSense forward-zone queries fail** — confirm the MetalLB IP is
+  correct: `kubectl -n dns get svc bind`. If MetalLB assigned a different
+  IP, update the OPNSense Domain Override.
+- **Zone file is stale after BIND restart** — BIND writes updates to a
+  journal file (`.jnl`) on the PVC. The PVC persists across restarts.
+  To force a fresh zone transfer, delete the PVC and let it reprovision:
+  `kubectl -n dns delete pvc bind-data && kubectl -n dns rollout restart deploy bind`.
+- **Too many NOTIFY messages** — BIND may try to NOTIFY its secondaries
+  on every update. The `allow-transfer { none; }` directive in
+  `named.conf` suppresses zone transfers and should suppress NOTIFY for
+  zones with no configured secondaries. If NOTIFY still appears in logs,
+  add `also-notify { };` to the zone block.

--- a/platform/dns/bind.yaml
+++ b/platform/dns/bind.yaml
@@ -1,0 +1,181 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rfc2136-tsig
+  namespace: dns
+type: Opaque
+stringData:
+  tsig-secret: "TqqKxVYG0Y68986d1zUe5bCyi3I0r9Cf8OnQHBDnwLo="
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bind-config
+  namespace: dns
+data:
+  named.conf: |
+    options {
+      directory "/var/bind/data";
+      listen-on { any; };
+      listen-on-v6 { none; };
+      allow-query { any; };
+      recursion no;
+      minimal-responses yes;
+      dnssec-validation auto;
+    };
+
+    key "external-dns." {
+      algorithm hmac-sha256;
+      secret "TqqKxVYG0Y68986d1zUe5bCyi3I0r9Cf8OnQHBDnwLo=";
+    };
+
+    zone "example.com" {
+      type primary;
+      file "/var/bind/data/example.com.zone";
+      allow-update { key "external-dns."; };
+      allow-transfer { none; };
+    };
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bind-seed-zone
+  namespace: dns
+data:
+  example.com.zone: |
+    $ORIGIN example.com.
+    $TTL 60
+    @   IN SOA  ns1.example.com. admin.example.com. (
+                2026061601 ; serial
+                3600       ; refresh
+                600        ; retry
+                86400      ; expire
+                60 )       ; minimum
+    @   IN NS   ns1.example.com.
+    ns1 IN A    10.72.16.51
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bind-data
+  namespace: dns
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bind
+  namespace: dns
+  labels:
+    app.kubernetes.io/name: bind
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bind
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bind
+    spec:
+      securityContext:
+        fsGroup: 101
+      initContainers:
+        - name: seed-zone
+          image: mirror.gcr.io/busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              if [ ! -f /var/bind/data/example.com.zone ]; then
+                cp /seed/example.com.zone /var/bind/data/
+                chown 100:101 /var/bind/data/example.com.zone
+              fi
+          volumeMounts:
+            - name: data
+              mountPath: /var/bind/data
+            - name: seed
+              mountPath: /seed
+              readOnly: true
+      containers:
+        - name: bind
+          image: internetsystemsconsortium/bind9:9.20
+          imagePullPolicy: IfNotPresent
+          args:
+            - named
+            - -c
+            - /etc/bind/named.conf
+            - -g
+            - -u
+            - bind
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/bind/named.conf
+              subPath: named.conf
+              readOnly: true
+            - name: data
+              mountPath: /var/bind/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 100
+            runAsGroup: 101
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: config
+          configMap:
+            name: bind-config
+        - name: seed
+          configMap:
+            name: bind-seed-zone
+        - name: data
+          persistentVolumeClaim:
+            claimName: bind-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bind
+  namespace: dns
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 10.72.16.51
+  labels:
+    app.kubernetes.io/name: bind
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: bind
+  ports:
+    - name: dns
+      port: 53
+      targetPort: 53
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      targetPort: 53
+      protocol: TCP

--- a/platform/dns/external-dns-cloudflare.yaml
+++ b/platform/dns/external-dns-cloudflare.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: bitnami-external-dns-cloudflare
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 8.7.10
+  url: oci://registry-1.docker.io/bitnamicharts/external-dns
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-cloudflare
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: bitnami-external-dns-cloudflare
+  upgrade:
+    crds: CreateReplace
+  values:
+    provider: cloudflare
+    registry: txt
+    txtOwnerId: external-dns-cloudflare
+    policy: sync
+    interval: 1m
+    logLevel: info
+    sources:
+      - service
+      - ingress
+      - gateway-httproute
+    domainFilters:
+      - example.com
+    cloudflare:
+      apiTokenExistingSecret: cloudflare-api-token
+      proxied: false
+      zoneId: REPLACE_WITH_CLOUDFLARE_ZONE_ID
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+    podSecurityContext:
+      fsGroup: 1001
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1001

--- a/platform/dns/external-dns-rfc2136.yaml
+++ b/platform/dns/external-dns-rfc2136.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: bitnami-external-dns-rfc2136
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 8.7.10
+  url: oci://registry-1.docker.io/bitnamicharts/external-dns
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-rfc2136
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: bitnami-external-dns-rfc2136
+  upgrade:
+    crds: CreateReplace
+  values:
+    provider: rfc2136
+    registry: txt
+    txtOwnerId: external-dns-rfc2136
+    policy: sync
+    interval: 1m
+    logLevel: info
+    sources:
+      - service
+      - ingress
+      - gateway-httproute
+    domainFilters:
+      - example.com
+    rfc2136:
+      host: "bind.dns.svc.cluster.local"
+      port: 53
+      zone: example.com
+      tsigKeyname: external-dns.
+      tsigSecretAlg: hmac-sha256
+      existingSecret: rfc2136-tsig
+      tsigAXFR: false
+      minTTL: 60s
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+    podSecurityContext:
+      fsGroup: 1001
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1001

--- a/platform/dns/kustomization.yaml
+++ b/platform/dns/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dns
+resources:
+- namespace.yaml
+- bind.yaml
+- external-dns-cloudflare.yaml
+- external-dns-rfc2136.yaml

--- a/platform/dns/namespace.yaml
+++ b/platform/dns/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dns
+  labels:
+    app.kubernetes.io/part-of: dns

--- a/platform/dns/secrets.example.yaml
+++ b/platform/dns/secrets.example.yaml
@@ -1,0 +1,20 @@
+---
+# This file documents the Secret shapes; actual Secrets are created
+# out-of-band (see platform/dns/README.md). They are NOT applied by kustomize.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-api-token
+  namespace: dns
+type: Opaque
+stringData:
+  api-token: REPLACE_WITH_CLOUDFLARE_API_TOKEN
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rfc2136-tsig
+  namespace: dns
+type: Opaque
+stringData:
+  tsig-secret: REPLACE_WITH_RFC2136_TSIG_KEY

--- a/platform/kustomization.yaml
+++ b/platform/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - crossplane
   - database
+  - dns
   - garage
   - gateway
   - monitoring


### PR DESCRIPTION
## What

Replaces the etcd+CoreDNS+SkyDNS approach with a simpler architecture:
an in-cluster BIND 9 instance that ExternalDNS writes to via RFC 2136
(TSIG-secured dynamic updates), with OPNSense Unbound forwarding the
zone to BIND's MetalLB IP.

### Components

- **bind** — BIND 9 Deployment (hand-rolled, 1 replica, Longhorn PVC).
  Authoritative for the public zone on the internal side. Accepts RFC 2136
  updates from ExternalDNS. MetalLB LoadBalancer at `10.72.16.51`.
- **external-dns-cloudflare** — pushes records to Cloudflare API.
- **external-dns-rfc2136** — pushes the same records to the in-cluster
  BIND via TSIG-signed dynamic updates.

### Why this over the previous etcd+CoreDNS approach

- **One less data store** — no etcd. BIND writes its zone journal to a
  Longhorn PVC. Records are derivable from k8s sources.
- **Standard protocol** — RFC 2136 dynamic updates instead of SkyDNS
  etcd keys. Debugging works with `dig`, `rndc`, `named-checkzone`.
- **Fewer moving parts** — 1 container (BIND) vs 2 (etcd + CoreDNS).

## Architecture

```
HTTPRoute ──► ExternalDNS-cloudflare ──► Cloudflare API     (public)
Service LB ┘
HTTPRoute ──► ExternalDNS-rfc2136   ──► BIND (RFC 2136)    (internal)
Service LB ┘                              │
                                          │ MetalLB LB IP 10.72.16.51
                                          │
                                    OPNSense Unbound (forward-zone)
                                          ▲
                                    LAN clients
```

## Follow-up (not in this PR)

OPNSense config: one Domain Override in the OPNSense UI forwarding the
public zone → `10.72.16.51`. Documented in `platform/dns/README.md`.

## Operator steps (pre-merge or post-merge)

1. Create a Cloudflare API token with `Zone:DNS:Edit` scoped to the public zone
2. Find the Cloudflare zone ID
3. Replace `REPLACE_WITH_CLOUDFLARE_ZONE_ID` in `platform/dns/external-dns-cloudflare.yaml`
4. Create the Cloudflare token Secret:
   `kubectl -n dns create secret generic cloudflare-api-token --from-literal=api-token=...`
5. (Optional) Generate a fresh TSIG key with `tsig-keygen -a hmac-sha256 external-dns.`
   and update both `bind.yaml` (ConfigMap `bind-config`) and the Secret `rfc2136-tsig`.
   The pre-generated key in the PR works as-is for testing.
6. (After merge) Configure the OPNSense forward-zone per the README

## Verification (end-to-end)

See "Verification" in `platform/dns/README.md`. Includes a smoketest
HTTPRoute and `dig` commands to confirm both providers see the new record.

## Notes

- **TSIG key** is pre-generated and hardcoded in `bind.yaml` (for BIND's
  `named.conf`) and replicated in the Secret `rfc2136-tsig` (for
  ExternalDNS). This is a homelab — the key only authenticates in-cluster
  RFC 2136 updates. Replace it if you want a unique key.
- **BIND zone file** is seeded from a ConfigMap (init container) and
  persists updates on a Longhorn PVC. Zone journal survives restarts.
- **Cloudflare token** lives in a Kubernetes Secret (not SOPS-encrypted
  in git). Future work: extend `.sops.yaml` to cover the `dns` namespace.

## Files

- New: `platform/dns/README.md`
- New: `platform/dns/bind.yaml`
- New: `platform/dns/external-dns-cloudflare.yaml`
- New: `platform/dns/external-dns-rfc2136.yaml`
- New: `platform/dns/kustomization.yaml`
- New: `platform/dns/namespace.yaml`
- New: `platform/dns/secrets.example.yaml`
- Modify: `platform/kustomization.yaml` (add `dns` to resources list)
