### PR TITLE
fix(automation): remove hermes-agent NetworkPolicy

### DIFF
--- a/services/automation/hermes-agent.yaml
+++ b/services/automation/hermes-agent.yaml
@@ -204,29 +204,6 @@ spec:
       enabled: true
       minAvailable: 1
 
-    # Restrict ingress to the gateway namespace (Envoy Gateway) and
-    # monitoring namespace (Prometheus scrapes). The policy is additive
-    # with any Kyverno-generated network policies in the namespace.
-    networkPolicy:
-      enabled: true
-      policyTypes:
-        - Ingress
-      ingress:
-        - from:
-            - namespaceSelector:
-                matchLabels:
-                  kubernetes.io/metadata.name: gateway
-            - namespaceSelector:
-                matchLabels:
-                  kubernetes.io/metadata.name: monitoring
-          ports:
-            - port: 9119
-              protocol: TCP
-            - port: 8644
-              protocol: TCP
-            - port: 8642
-              protocol: TCP
-
     # ServiceAccount: use the pre-created `hermes-viewer` SA in this
     # namespace (see core/hermes-viewer/) and mount its token so the
     # in-cluster Python kubernetes client can authenticate automatically.


### PR DESCRIPTION
## Problem

Hermes dashboard returning "upstream connect error" and webhook listener intermittently returning 503.

## Root cause

Envoy proxy logs showed recurring 503 responses on `hermes-webhook.zro.io` with CDS churn (backend clusters removed and re-added). The NetworkPolicy restricting ingress to gateway+monitoring namespaces — added in #ebf30c36 — may be interfering with endpoint health checks or creating a narrow failure window during endpoint updates.

## Verification

- All three hermes ports (8642 api-server, 8644 webhook, 9119 dashboard) respond HTTP 200 from inside the cluster, both directly and through the Envoy proxy
- External access works from the cluster side (Cloudflare → MetalLB → Envoy → backend)
- NetworkPolicies are not currently in use — removing eliminates one variable

## Change

Remove the `networkPolicy` block from the hermes-agent HelmRelease values.