### PR TITLE
fix(garage): fix bootstrap job

### DIFF
--- a/platform/garage/bootstrap-config.yaml
+++ b/platform/garage/bootstrap-config.yaml
@@ -1,5 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/configmap.json
+# admin_keys: keys granted owner access to every bucket automatically
 # Add a bucket:  {"name": "mybucket"}
 # Add key access: {"name": "mybucket", "keys": ["myapp"]}
 # Key names must match a credential added via: scripts/garage-creds add myapp
@@ -10,6 +11,7 @@ metadata:
 data:
   buckets.json: |
     {
+      "admin_keys": [],
       "buckets": [
         {"name": "family"},
         {"name": "public"},

--- a/platform/garage/bootstrap.yaml
+++ b/platform/garage/bootstrap.yaml
@@ -81,7 +81,21 @@ data:
         })
         imported[key_label] = access_key
 
-    # Create buckets and assign permissions
+    def allow(bucket_id, key_name):
+        ak = imported.get(key_name) or os.environ.get(f"S3_{key_name.upper()}_ACCESS_KEY", "")
+        if not ak:
+            print(f"  Key '{key_name}' not in env, skipping")
+            return
+        print(f"  Allowing {key_name}")
+        api("POST", "/v2/AllowBucketKey", {
+            "bucketId":    bucket_id,
+            "accessKeyId": ak,
+            "permissions": {"read": True, "write": True, "owner": True},
+        })
+
+    # Create buckets, collect IDs, assign per-bucket keys
+    admin_keys = config.get("admin_keys", [])
+    bucket_ids = {}
     for bucket in config["buckets"]:
         name   = bucket["name"]
         print(f"==> Bucket: {name}")
@@ -91,18 +105,16 @@ data:
         else:
             info      = api("GET", f"/v2/GetBucketInfo?alias={name}&globalAlias")
             bucket_id = info["id"]
+        bucket_ids[name] = bucket_id
 
         for key_name in bucket.get("keys", []):
-            ak = imported.get(key_name) or os.environ.get(f"S3_{key_name.upper()}_ACCESS_KEY", "")
-            if not ak:
-                print(f"  Key '{key_name}' not in env, skipping permission")
-                continue
-            print(f"  Allowing {key_name} → {name}")
-            api("POST", "/v2/AllowBucketKey", {
-                "bucketId":    bucket_id,
-                "accessKeyId": ak,
-                "permissions": {"read": True, "write": True, "owner": True},
-            })
+            allow(bucket_id, key_name)
+
+    # Grant admin keys access to every bucket
+    for key_name in admin_keys:
+        for name, bucket_id in bucket_ids.items():
+            print(f"==> Admin key {key_name} → {name}")
+            allow(bucket_id, key_name)
 
     print("==> Bootstrap complete.")
 

--- a/platform/garage/bootstrap.yaml
+++ b/platform/garage/bootstrap.yaml
@@ -50,15 +50,15 @@ data:
     node_id = nodes[0]["id"]
     print(f"==> Node: {node_id[:12]}...")
 
-    print("==> Updating layout (500 GiB)...")
-    api("POST", "/v2/UpdateClusterLayout", {
-        "roles": {node_id: {"zone": "default", "capacity": 536870912000, "tags": []}}
-    })
     if status.get("layoutVersion", 0) == 0:
+        print("==> Assigning layout (500 GiB)...")
+        api("POST", "/v2/UpdateClusterLayout", {
+            "roles": [{"id": node_id, "zone": "default", "capacity": 536870912000, "tags": []}]
+        })
         print("==> Applying layout version 1...")
         api("POST", "/v2/ApplyClusterLayout", {"version": 1})
     else:
-        print(f"==> Layout at v{status.get('layoutVersion')}, skipping apply.")
+        print(f"==> Layout at v{status.get('layoutVersion')}, skipping.")
 
     with open("/config/buckets.json") as f:
         config = json.load(f)


### PR DESCRIPTION
## Summary

- Fix `UpdateClusterLayout` request body — `roles` must be an array `[{id, zone, capacity, tags}]`, not a map; this was causing 400 errors and the Job exhausting its backoff limit
- Scope layout assignment to only run when `layoutVersion == 0` (fresh cluster) so re-runs don't stage unnecessary changes
- Add `admin_keys` support in `bootstrap-config.yaml` — keys listed there get owner access to every bucket automatically

## Test plan

- [ ] Delete the failed Job: `kubectl delete job garage-bootstrap -n garage`
- [ ] Merge and let Flux reconcile (or `flux reconcile kustomization platform --with-source`)
- [ ] Confirm Job completes: `kubectl -n garage get job garage-bootstrap`
- [ ] Confirm buckets exist: `kubectl -n garage exec deploy/garage -- /garage bucket list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)