### PR TITLE
feat(scripts): add cluster-secrets helper for config/secrets.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,12 @@ flux get helmreleases -A
 # Edit the (only) SOPS-encrypted file; PGP keys are in .sops.yaml
 sops config/secrets.yaml
 
+# Manage cluster-secrets keys without hand-editing SOPS (value from stdin if omitted)
+scripts/cluster-secrets set|get|list|remove <KEY>
+
+# Manage garage S3 credentials in platform/garage/s3-keys.yaml
+scripts/garage-creds add|list|show|remove <name>
+
 # Cluster provisioning / upgrades (k0sctl config)
 k0sctl apply --config config/cluster.yaml
 ```

--- a/scripts/cluster-secrets
+++ b/scripts/cluster-secrets
@@ -40,7 +40,6 @@ cmd_set() {
   echo "Next steps:"
   echo "  1. git add config/secrets.yaml"
   echo "  2. git commit && git push"
-  echo "  3. flux reconcile kustomization core --with-source  # (then dependent layers)"
 }
 
 cmd_list() {

--- a/scripts/cluster-secrets
+++ b/scripts/cluster-secrets
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Manage keys in config/secrets.yaml (SOPS-encrypted cluster-secrets Secret).
+# Values land in the cluster-secrets Secret and are usable as ${KEY} via Flux
+# postBuild.substituteFrom on next reconcile.
+#
+# Usage:
+#   cluster-secrets set <KEY> [value]   # reads value from stdin if omitted
+#   cluster-secrets list                # show configured key names
+#   cluster-secrets get <KEY>           # decrypt and print a single value
+#   cluster-secrets remove <KEY>        # delete a key
+#   cluster-secrets edit                # open full file in $EDITOR
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SECRETS="$REPO_ROOT/config/secrets.yaml"
+
+_ensure_encrypted() {
+  if ! grep -q 'sops:' "$SECRETS" 2>/dev/null; then
+    echo "==> Encrypting $SECRETS with SOPS..."
+    sops --encrypt --in-place "$SECRETS"
+  fi
+}
+
+cmd_set() {
+  local key="${1:?Usage: cluster-secrets set <KEY> [value]}"
+  local value
+  if [[ $# -ge 2 ]]; then
+    value="$2"
+  else
+    echo "==> Reading value for '${key}' from stdin (Ctrl-D to end)..." >&2
+    value="$(cat)"
+  fi
+
+  _ensure_encrypted
+
+  sops --set "[\"stringData\"][\"${key}\"] \"${value}\"" "$SECRETS"
+
+  echo "==> Set '${key}'"
+  echo ""
+  echo "Next steps:"
+  echo "  1. git add config/secrets.yaml"
+  echo "  2. git commit && git push"
+  echo "  3. flux reconcile kustomization core --with-source  # (then dependent layers)"
+}
+
+cmd_list() {
+  if ! grep -q 'sops:' "$SECRETS" 2>/dev/null; then
+    echo "(no secrets configured — file is not yet encrypted)"
+    return
+  fi
+  sops --decrypt "$SECRETS" \
+    | grep -E '^[[:space:]]+[A-Za-z0-9_]+:' \
+    | grep -vE '^[[:space:]]*#' \
+    | sed -E 's/:.*//;s/^[[:space:]]*//' \
+    | grep -vE '^(apiVersion|kind|type|metadata|namespace|name|stringData|data|sops)$'
+}
+
+cmd_get() {
+  local key="${1:?Usage: cluster-secrets get <KEY>}"
+  sops --decrypt --extract "[\"stringData\"][\"${key}\"]" "$SECRETS"
+}
+
+cmd_remove() {
+  local key="${1:?Usage: cluster-secrets remove <KEY>}"
+  sops unset --idempotent "$SECRETS" "[\"stringData\"][\"${key}\"]"
+  echo "==> Removed '${key}'"
+}
+
+case "${1:-}" in
+  set)    shift; cmd_set "$@" ;;
+  list)   cmd_list ;;
+  get)    shift; cmd_get "$@" ;;
+  remove) shift; cmd_remove "$@" ;;
+  edit)   sops "$SECRETS" ;;
+  *)
+    sed -n '2,11p' "${BASH_SOURCE[0]}" | sed 's/^# //'
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## What

Adds `scripts/cluster-secrets`, a helper for managing keys in the SOPS-encrypted `config/secrets.yaml` (the `cluster-secrets` Secret that Flux substitutes as `${VAR}` via `postBuild.substituteFrom`) without hand-editing SOPS.

Modeled on the existing `scripts/garage-creds`.

```
cluster-secrets set <KEY> [value]   # value from stdin if omitted (avoids shell history)
cluster-secrets get <KEY>           # decrypt + print one value
cluster-secrets list                # list configured key names
cluster-secrets remove <KEY>        # delete a key (sops unset --idempotent)
cluster-secrets edit                # open full file in $EDITOR
```

Also documents both `cluster-secrets` and the pre-existing `garage-creds` in CLAUDE.md's Common commands.

## Notes

- `set` reads from stdin when the value is omitted, keeping secrets out of shell history.
- `remove` uses `sops unset` for a clean single-key delete (vs. the editor-based approach `garage-creds` uses for its key pairs).
- Every write re-randomizes the SOPS `mac`/`lastmodified` metadata, so each edit produces a small diff even when logically idempotent — inherent to SOPS.

## Testing

Ran the full set → get → list → remove roundtrip against the real encrypted file: GPG decryption works, value written/read back correctly, removed cleanly, and the only resulting diff was the expected `mac`/`lastmodified` metadata (all existing data keys intact). File restored afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)