### PR TITLE
feat(garage): serve web sites under WEB_DOMAIN with its own gateway cert

### DIFF
--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -113,10 +113,11 @@ stringData:
     VELERO_B2_ENDPOINT: ENC[AES256_GCM,data:R4lFtpikDWyOkAYcgT7aEJnbTMLmWRkLpMO7sNmt,iv:hU7vLP8PGqL/7PfY1KoOY1bwSud7UO+pnEyzxpMLScY=,tag:WDuuZm+PvBasjKzXLXAMNg==,type:str]
     VELERO_B2_KEY_ID: ENC[AES256_GCM,data:n21GyM+lj0dna8LVbwKtEdTcZ6GC50hBAg==,iv:9M+g1xQZ8ShDA3pTtUeoCwZSwfRmJ6VfOl40J+ix0Mo=,tag:xFtQCVmahYuYsuDJVN4jCQ==,type:str]
     VELERO_B2_APPLICATION_KEY: ENC[AES256_GCM,data:TKWWEiq8N6mLp3Eo44P6xdo+oh2d80a8/qdMUTI21w==,iv:86KdgJ6P2hH5FmFuWI7c9TvDvpVVH2XNWlTLtCOtTAw=,tag:TuKg0xwjbmq2ntafqHvJiQ==,type:str]
+    WEB_DOMAIN: ENC[AES256_GCM,data:Fy0ab7PvSYa/,iv:mVZBbatcXif73GY8S7dPyPr3d6ObfFQrXTTtuBTQ0CA=,tag:yZjELdHkuA3KIptiSIcRBA==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-28T04:33:08Z"
-    mac: ENC[AES256_GCM,data:7899SVVsMjKtznUFepNVTRfF+/B0td396T4uDbQXlwu4oWWC478mED2LPuF0Htpc1bsRGv/cp4wA8wNSDIo4P7xrCg81YwURP7gHeu4fFa8a27y137Jf+oPTQ4kJXMqpcG3aTGDEE1ZxsxP/96/vutUY+eNAD45dMomq8AcA+Zo=,iv:AyYYQOvjdAjn9Ek48iSn/hcBtz/TRmyj6S6IFdQruYc=,tag:VN1sEu1Nl6hYGNamwLMZOw==,type:str]
+    lastmodified: "2026-06-28T05:08:22Z"
+    mac: ENC[AES256_GCM,data:newVzfxWlXybzpjtHOrl6Vjqx2RjcGqaokIuzry7LAt7dZQwI9i6Svb6WFzRDDO/VQUM2pKVF6rj3b65byboiIcTLLDxX1kG6ZeuwsebB6Q7xx3o8TeV9nve86xdJ64JhljiQ4dCZBbX/6n2peaas4ydoTDViH5JvB+cc4Hgw6Y=,iv:Tl0Z6gu5PZF7gdJh1uSixSiXamnGWnIaISQ31qMxQXY=,tag:qIdQ4NB8QhdBdi4iVanRzA==,type:str]
     pgp:
         - created_at: "2026-06-08T03:22:24Z"
           enc: |-

--- a/core/resources/kustomization.yaml
+++ b/core/resources/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - cert-manager.yaml
 - hardware.yaml
 - gateway-certificate.yaml
+- web-domain-certificate.yaml
 - metallb.yaml

--- a/core/resources/web-domain-certificate.yaml
+++ b/core/resources/web-domain-certificate.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/certificate_v1.json
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: &name web-domain-tls
+  namespace: gateway
+spec:
+  secretName: *name
+  duration: 2160h0m0s
+  renewBefore: 720h0m0s
+  subject:
+    organizations: ["${ORGANIZATION_NAME}"]
+  commonName: "${WEB_DOMAIN}"
+  dnsNames:
+    - "${WEB_DOMAIN}"
+    - "*.${WEB_DOMAIN}"
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt

--- a/platform/garage/configuration.yaml
+++ b/platform/garage/configuration.yaml
@@ -22,7 +22,7 @@ data:
 
     [s3_web]
     bind_addr = "[::]:3902"
-    root_domain = ".web.${CLUSTER_DOMAIN}"
+    root_domain = ".${WEB_DOMAIN}"
     index = "index.html"
 
     [admin]

--- a/platform/garage/release.yaml
+++ b/platform/garage/release.yaml
@@ -62,7 +62,7 @@ spec:
                 port: *s3-port
       web:
         enabled: true
-        hostnames: ["*.web.${CLUSTER_DOMAIN}"]
+        hostnames: ["*.${WEB_DOMAIN}"]
         parentRefs:
           - name: external
             namespace: gateway

--- a/platform/gateway/gateway.yaml
+++ b/platform/gateway/gateway.yaml
@@ -70,3 +70,5 @@ spec:
         certificateRefs:
           - kind: Secret
             name: default-wildcard-tls
+          - kind: Secret
+            name: web-domain-tls


### PR DESCRIPTION
## What

Move Garage's S3 website hosting off the cluster wildcard domain onto a dedicated public domain (`WEB_DOMAIN`). Buckets are now served at `<bucket>.${WEB_DOMAIN}` instead of `<bucket>.web.${CLUSTER_DOMAIN}`, with a **separate** gateway certificate for it.

The domain itself stays in the `WEB_DOMAIN` cluster-secret — no file name, resource name, or manifest contains it literally.

## Changes

| File | Change |
|------|--------|
| `core/resources/web-domain-certificate.yaml` *(new)* | Separate `web-domain-tls` Certificate in the `gateway` namespace — apex + `*.${WEB_DOMAIN}`, issued by the existing `letsencrypt` ClusterIssuer (Cloudflare DNS-01) |
| `core/resources/kustomization.yaml` | Register the new cert |
| `platform/gateway/gateway.yaml` | Add `web-domain-tls` as a **second** `certificateRef` on the existing HTTPS listener — Envoy selects per-host via SNI, port 443 stays shared |
| `platform/garage/configuration.yaml` | `[s3_web] root_domain = ".${WEB_DOMAIN}"` |
| `platform/garage/release.yaml` | web route hostnames → `*.${WEB_DOMAIN}` |

All three affected kustomize layers (`core/resources`, `platform/gateway`, `platform/garage`) render clean.

## Required before reconcile

The `WEB_DOMAIN` substitution var must be set first, or layers render a literal `${WEB_DOMAIN}`:

\`\`\`sh
scripts/cluster-secrets set WEB_DOMAIN <your-domain>
\`\`\`

Then commit the updated `config/secrets.yaml` and reconcile core-resources → platform.

## Worth flagging

- **Cloudflare token scope:** the existing `cloudflare-token` must have DNS edit rights on the new zone, or the DNS-01 challenge fails.
- **DNS:** needs a `*.<domain>` (and apex, if used) record pointing at `${LOAD_BALANCER_GATEWAY}`.
- **Dead SAN (optional):** `*.web.${CLUSTER_DOMAIN}` in `gateway-certificate.yaml` is now unused; left in place to avoid re-issuing the wildcard cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)