### PR TITLE
feat(velero): add otwld web UI + Grafana dashboard

### DIFF
--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -116,10 +116,14 @@ stringData:
     CERT_MANAGER_CLOUDFLARE_TOKEN: ENC[AES256_GCM,data:RKfPlGwY7a2mXVzw1fajx9W36l5zfboXsIgzWZ9EcT57kip2sNR9sQ==,iv:VUe3D9DkUgcfmo1M2Ucaj1PfL7W5FaGZaQx3V4cz7zM=,tag:gjiWZVsq7sqfAKbuLAVV1g==,type:str]
     EXTERNAL_DNS_CLOUDFLARE_TOKEN: ENC[AES256_GCM,data:sxsngbZwz4AxeIyI4qKnG5TV4yq6EDDNzsEUTXaQzST92JWMFlmoenJxi7bkBPAL14R6hLU=,iv:DXGnN4CDmWm2ryJ+qNbvxpwspwHfi+gBcVi/jwdUsWE=,tag:iSUPcTpawfl11cuMSChlSg==,type:str]
     CLOUD_EXTERNAL_IP: ENC[AES256_GCM,data:BoiUtxcvFnba1aOr2Oc=,iv:davw8R/PBgx9dlnZ19q4qWkGvAXZwCWToE5682SG9gU=,tag:HjU78MPhkwRwXenUj925hA==,type:str]
+    OIDC_VELERO_UI_CLIENT_ID: ENC[AES256_GCM,data:vVQ3BhxsnlwzkXEEyN81ydXaed+GONSNK6vcozrrwjLbMfj8,iv:4hTOqZWYNROqISCBaCeiWASSnpKgXvvohI/bFu6dDwQ=,tag:1WFdKdGQhq1kVqujFmuIYQ==,type:str]
+    OIDC_VELERO_UI_CLIENT_SECRET: ENC[AES256_GCM,data:RvNU96cIK1xrKA+NFm5rPanOhRwXnQrCPK7OvmVwxW4=,iv:4DbkfSB5h0BNYeMhSTrRicsc1CJ8cwDTZ0YPfU+IqVg=,tag:huAPL1gwssAOdg9W2KyWTQ==,type:str]
+    VELERO_UI_ADMIN_PASSWORD: ENC[AES256_GCM,data:N7WBIAetjidGaJYgwULUGgcUcPTqDY5tMtc+tHAGPc4=,iv:xnM/yPu4BURAGST74Q3P7g66lrI9PBnkeNN1UxitlNE=,tag:yeibmtwivuabwfYinhAwMw==,type:str]
+    VELERO_UI_PASSPHRASE: ENC[AES256_GCM,data:oUHMhd1k2aU6dgfKR7ua5baUKXB9ei6f9v5w31wwWvp6Tyz6kQhEhriHzrCQQipNQHGmxwTY2GUMCJj98TFntg==,iv:4LUjUdnG3gOVbmhYxAIxki5W4HuU2pSXItEblI5hS/Y=,tag:FV4RczXYKXVoq9ZvP/esHA==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-28T06:18:37Z"
-    mac: ENC[AES256_GCM,data:QMO7fymuG+wAfusB502P4dhNDaAl84MYeSCVVf+eN+L/bJGwsEv/xKNlge4LTsMTsGZJxcmf7/I6CpH43aTGChyLINisMep04veSjOL0nbKT+/0EVqzid7iE0gZQVecRw9r50nJLw0w+gpmARMdqOznOFYdOZ2EKp/d59uIPAg4=,iv:fPIb6r0v4p4YZS1T1WTZl41sd/3w+wbK6fwauxHVmHQ=,tag:i1YWT6FrqaISUnqpSLl82Q==,type:str]
+    lastmodified: "2026-06-28T07:06:40Z"
+    mac: ENC[AES256_GCM,data:KpO5bxaOt6JGjh7R48Sq+4gTVWNw6c4EPevdrh4WVAxkd93kL0bb08d3SwQ8sdE6nMMlZrrS6HzqecdECjKZe11Wm84mUzURT3pivRzymOx2+B73UDuh7gzFU8r+R0jVlFZWiKYet7fN9nMPIwx6BM4p14xK+FE34arvqxG1Sl0=,iv:+O1lfcqd0MNR9WrOLD4qAl56QTM88vVVsj1REKlkWxo=,tag:c5jm7PAcJ7LtT7p/s95X/A==,type:str]
     pgp:
         - created_at: "2026-06-08T03:22:24Z"
           enc: |-

--- a/platform/velero/README.md
+++ b/platform/velero/README.md
@@ -12,6 +12,8 @@ Cluster-level backup and restore using Velero, backed by Backblaze B2 (S3-compat
 
 - [Architecture](#architecture)
 - [What's deployed](#whats-deployed)
+- [Web UI](#web-ui)
+- [Grafana dashboard](#grafana-dashboard)
 - [One-time bootstrap](#one-time-bootstrap)
 - [Adding a backup schedule](#adding-a-backup-schedule)
 - [Excluding resources and volumes](#excluding-resources-and-volumes)
@@ -102,8 +104,46 @@ The broad sweeps (`daily-cluster`, `weekly-full`) are **manifests only** (`snaps
 | `Schedule/daily-cluster` | velero | Cluster-wide daily backup (manifests) |
 | `Schedule/daily-critical` | velero | Critical namespaces daily (with snapshots) |
 | `Schedule/weekly-full` | velero | Weekly full backup, manifests (90d retention) |
+| `HelmRelease/velero-ui` | velero | otwld Velero UI web dashboard (`ui.yaml`) |
+| `HelmRepository/otwld` | velero | Chart source for velero-ui |
+| `HTTPRoute/velero-ui` | velero | `velero.${CLUSTER_DOMAIN}`, behind pocket-id OIDC |
+| `GrafanaDashboard/velero` | velero | grafana.com 16829, scrapes the ServiceMonitor metrics |
 
 Velero is applied by the `platform` Flux Kustomization (it's listed in `platform/kustomization.yaml`), not a dedicated Flux pointer.
+
+---
+
+## Web UI
+
+Velero itself has **no built-in web UI** — the `velero` CLI is the official interface. For a browser dashboard we run [otwld/velero-ui](https://github.com/otwld/velero-ui) (`ui.yaml`), a realtime UI that connects to the existing Velero install (it does **not** deploy its own Velero). It lists/creates/deletes backups, restores, and schedules, and shows backup status at a glance. The `velero` CLI remains the source of truth for scripting and disaster recovery.
+
+Reachable at `https://velero.${CLUSTER_DOMAIN}`.
+
+**RBAC scope:** the chart's `rbac.create` mints a ClusterRole limited to `velero.io/*` CRs plus read-only `namespaces`; `rbac.clusterAdministrator: false` keeps the UI's ServiceAccount **off** the `cluster-admin` binding. So the UI can manage Velero objects (including creating/deleting backups and running restores) but has no reach into anything else. To make it strictly read-only, you'd have to disable `rbac.create` and supply your own ClusterRole with only `get/list/watch` on `velero.io`.
+
+**Auth — native pocket-id OIDC:** the app authenticates directly against pocket-id (`OAUTH_*` env, see `ui.yaml`), so login goes through SSO and the logged-in identity maps to the UI's in-app RBAC by **group claim** (`OAUTH_GROUP_CLAIM=groups`). That gives per-user roles instead of one shared login. The route carries **no** gateway-level OIDC label — the app owns the login flow. The built-in `BASIC_AUTH` admin (`VELERO_UI_ADMIN_PASSWORD`) is kept as a **break-glass** login: use it to sign in the first time and configure the group → role policies (see the [Velero UI RBAC docs](https://velero-ui.docs.otwld.com/sso-ldap/rbac)).
+
+### Velero UI bootstrap
+
+1. **Register an OIDC client in pocket-id** with callback URL `https://velero.${CLUSTER_DOMAIN}/login`. Enable the **groups** scope/claim on the client, and create/assign a group (e.g. `velero-admins`) for the people who should administer backups.
+2. **Add to `config/secrets.yaml`** (via `sops config/secrets.yaml`):
+   ```yaml
+   OIDC_VELERO_UI_CLIENT_ID:     <pocket-id client id>
+   OIDC_VELERO_UI_CLIENT_SECRET: <pocket-id client secret>
+   VELERO_UI_ADMIN_PASSWORD:     <break-glass password for the admin login>
+   VELERO_UI_PASSPHRASE:         <random string; signs the app's session JWTs>
+   ```
+   The OIDC endpoint URLs and scopes are non-secret and live in `ui.yaml` (`OAUTH_AUTHORIZATION_URL`/`OAUTH_TOKEN_URL`/`OAUTH_USER_INFO_URL` point at `id.${CLUSTER_DOMAIN}`).
+3. **Reconcile** — `flux reconcile kustomization platform --with-source`, then browse to `https://velero.${CLUSTER_DOMAIN}`.
+4. **Map the group to a role** — sign in once with the break-glass admin, then add an RBAC policy binding the `velero-admins` group (from the OIDC group claim) to an admin role. After that, group members sign in via "Pocket ID" and get the right permissions automatically.
+
+> If OIDC login fails with an invalid-scope error, your pocket-id client doesn't expose the `groups` scope — drop `groups` from `OAUTH_OAUTH_SCOPE` in `ui.yaml` (you lose group-based RBAC but SSO login still works).
+
+---
+
+## Grafana dashboard
+
+The HelmRelease enables Velero metrics + a `ServiceMonitor` (`values.metrics.serviceMonitor`), so Prometheus scrapes the `velero_*` series. `dashboard.yaml` adds the Velero-team-maintained Grafana dashboard ([grafana.com 16829](https://grafana.com/grafana/dashboards/16829-kubernetes-tanzu-velero/)) as a `GrafanaDashboard` CR — backup/restore success rates, CSI snapshots, and node-agent (filesystem) backups. It loads automatically once Flux reconciles; no Grafana clicks needed.
 
 ---
 

--- a/platform/velero/dashboard.yaml
+++ b/platform/velero/dashboard.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: velero
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  # Velero-team-maintained dashboard, targets the velero_* metrics scraped via
+  # the ServiceMonitor enabled in helmrelease.yaml (values.metrics.serviceMonitor).
+  # Ref: https://grafana.com/grafana/dashboards/16829-kubernetes-tanzu-velero/
+  grafanaCom:
+    id: 16829
+    revision: 5

--- a/platform/velero/kustomization.yaml
+++ b/platform/velero/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - secret.yaml
   - helmrelease.yaml
   - volume-policy.yaml
+  - dashboard.yaml
+  - ui.yaml

--- a/platform/velero/ui.yaml
+++ b/platform/velero/ui.yaml
@@ -1,0 +1,156 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+#
+# otwld Velero UI — a realtime web dashboard for Velero. It connects to the
+# existing Velero install in this namespace (VELERO_NAMESPACE=velero); it does
+# NOT deploy its own Velero. See https://github.com/otwld/velero-ui.
+#
+# Auth: the app authenticates natively against pocket-id via OIDC (OAUTH_* env).
+# Logged-in identity maps to the UI's in-app RBAC by group claim, so you get
+# per-user roles instead of one shared login. The built-in BASIC_AUTH admin is
+# kept as a break-glass login (use it to configure the group → role policies).
+# The route itself carries no gateway OIDC — the app owns the login flow.
+#
+# config/secrets.yaml already provides (via `sops config/secrets.yaml`):
+#   OIDC_VELERO_UI_CLIENT_ID:     <pocket-id client id for velero-ui>
+#   OIDC_VELERO_UI_CLIENT_SECRET: <pocket-id client secret>
+#   VELERO_UI_ADMIN_PASSWORD:     <break-glass password for the admin login>
+#   VELERO_UI_PASSPHRASE:         <random string, signs the app's JWTs>
+#
+# In pocket-id, the velero-ui OIDC client needs:
+#   - callback URL https://velero.${CLUSTER_DOMAIN}/login
+#   - the groups scope/claim enabled (for the RBAC group mapping below)
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: otwld
+  namespace: velero
+spec:
+  interval: 12h
+  # otwld publishes only a classic Helm repo, not an OCI artifact.
+  url: https://helm.otwld.com
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/secret.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-ui-secret
+  namespace: velero
+type: Opaque
+stringData:
+  # Break-glass built-in login (OIDC is the primary path).
+  BASIC_AUTH_USERNAME: admin
+  BASIC_AUTH_PASSWORD: ${VELERO_UI_ADMIN_PASSWORD}
+  # Signs the app's session JWTs.
+  AUTH_SECRET_PASSPHRASE: ${VELERO_UI_PASSPHRASE}
+  # pocket-id OIDC client credentials (consumed as OAUTH_CLIENT_ID/SECRET).
+  OAUTH_CLIENT_ID: ${OIDC_VELERO_UI_CLIENT_ID}
+  OAUTH_CLIENT_SECRET: ${OIDC_VELERO_UI_CLIENT_SECRET}
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: velero-ui
+  namespace: velero
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: velero-ui
+      version: 0.14.0
+      sourceRef:
+        kind: HelmRepository
+        name: otwld
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: otwld/velero-ui
+    replicaCount: 1
+
+    service:
+      type: ClusterIP
+      port: 3000
+
+    # rbac.create makes a ClusterRole scoped to velero.io/* CRs + read-only on
+    # namespaces — exactly what the UI needs to manage backups/restores.
+    # clusterAdministrator: false keeps it OFF the cluster-admin binding, so the
+    # UI's ServiceAccount has zero reach outside Velero objects.
+    rbac:
+      create: true
+      clusterAdministrator: false
+    serviceAccount:
+      create: true
+
+    configuration:
+      logLevel: info
+      general:
+        veleroNamespace: velero
+        grafanaUrl: https://grafana.${CLUSTER_DOMAIN}
+        # We supply the passphrase via envFrom (velero-ui-secret); don't let the
+        # chart mint its own placeholder passphrase Secret.
+        secretPassPhrase:
+          useSecret: false
+
+    # Non-secret OIDC wiring for pocket-id (id.${CLUSTER_DOMAIN}). The client
+    # id/secret come from velero-ui-secret via envFrom below.
+    env:
+      - name: OAUTH_AUTH_ENABLED
+        value: "true"
+      - name: OAUTH_NAME
+        value: Pocket ID
+      - name: OAUTH_AUTHORIZATION_URL
+        value: https://id.${CLUSTER_DOMAIN}/authorize
+      - name: OAUTH_TOKEN_URL
+        value: https://id.${CLUSTER_DOMAIN}/api/oidc/token
+      - name: OAUTH_USER_INFO_URL
+        value: https://id.${CLUSTER_DOMAIN}/api/oidc/userinfo
+      - name: OAUTH_REDIRECT_URI
+        value: https://velero.${CLUSTER_DOMAIN}/login
+      # 'groups' included so pocket-id returns group memberships for RBAC.
+      - name: OAUTH_OAUTH_SCOPE
+        value: openid profile email groups
+      - name: OAUTH_GROUP_CLAIM
+        value: groups
+
+    # Break-glass admin login, JWT passphrase, and OIDC client creds.
+    envFrom:
+      - secretRef:
+          name: velero-ui-secret
+
+    # Ingress is Gateway API in this repo (HTTPRoute below), not the chart's
+    # Ingress resource.
+    ingress:
+      enabled: false
+
+    resources:
+      requests:
+        cpu: 25m
+        memory: 96Mi
+      limits:
+        memory: 256Mi
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: velero-ui
+  namespace: velero
+  # No gateway-level OIDC label: the app authenticates against pocket-id itself
+  # (OAUTH_* env), so SSO is enforced in-app, not by the gateway.
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+  hostnames:
+    - velero.${CLUSTER_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: velero-ui
+          port: 3000


### PR DESCRIPTION
## What

Adds a web UI and a Grafana dashboard to the existing Velero deployment.

- **Web UI** — Velero has no native UI, so deploy [otwld/velero-ui](https://github.com/otwld/velero-ui) (chart `0.14.0`), a realtime dashboard that connects to the existing Velero install (does **not** redeploy Velero). Exposed at `velero.${CLUSTER_DOMAIN}` via a Gateway API `HTTPRoute`.
- **Grafana dashboard** — `GrafanaDashboard` CR pulling [grafana.com 16829](https://grafana.com/grafana/dashboards/16829-kubernetes-tanzu-velero/) (Velero-team maintained) over the `velero_*` metrics the existing ServiceMonitor already scrapes.

## Auth & RBAC

- **Native pocket-id OIDC** — the app authenticates directly against `id.${CLUSTER_DOMAIN}` (`OAUTH_*` env, endpoints verified against pocket-id + the otwld source). Logged-in identity maps to the UI's in-app RBAC by group claim (`OAUTH_GROUP_CLAIM=groups`). Built-in `BASIC_AUTH` admin kept as **break-glass**.
- **Scoped ServiceAccount** — `rbac.clusterAdministrator: false`, so the UI is limited to `velero.io/*` CRs + read-only `namespaces`. **Not** cluster-admin (the chart default, deliberately disabled).

## Files

- `platform/velero/ui.yaml` — HelmRepository (otwld), Secret, HelmRelease, HTTPRoute
- `platform/velero/dashboard.yaml` — GrafanaDashboard
- `platform/velero/kustomization.yaml`, `README.md` — wire-up + docs
- `config/secrets.yaml` — `OIDC_VELERO_UI_*` / `VELERO_UI_*` (SOPS-encrypted)

## Before merge — manual pocket-id setup

1. Register the velero-ui OIDC client with callback `https://velero.${CLUSTER_DOMAIN}/login` and enable the **groups** scope/claim; assign an admin group (e.g. `velero-admins`).
2. After it's up: sign in once with the break-glass admin and bind that group to an admin role.

> The four `${...}` secret values are already in `config/secrets.yaml`. ⚠️ If the pocket-id client lacks a `groups` scope, OIDC login fails with `invalid_scope` — drop `groups` from `OAUTH_OAUTH_SCOPE` in `ui.yaml` (SSO still works, group RBAC lost). See the README Web UI section.

## Validation

`kubectl kustomize platform/velero/` and `kubectl kustomize platform/` both render clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)