### PR TITLE
fix(database): bump Kafka version from 4.1.0 to 4.3.0

### DIFF
--- a/platform/database/kafka.yaml
+++ b/platform/database/kafka.yaml
@@ -26,7 +26,7 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 4.1.0
+    version: 4.3.0
     listeners:
       - name: plain
         port: 9092


### PR DESCRIPTION
Strimzi operator only supports Kafka versions `[4.2.0, 4.2.1, 4.3.0]`. The Kafka cluster is currently pinned to `4.1.0`, which is unsupported and leaves the cluster in a degraded state.

This bumps `spec.kafka.version` to `4.3.0` — the latest stable in the supported range.