### PR TITLE
fix(hermes-agent): allow writes to /tmp via HERMES_WRITE_SAFE_ROOT

### DIFF
--- a/services/automation/hermes-agent.yaml
+++ b/services/automation/hermes-agent.yaml
@@ -97,6 +97,7 @@ spec:
       SLACK_ALLOWED_USERS: ${HERMES_SLACK_ALLOWED_USERS}
       SIGNAL_ALLOWED_USERS: ${HERMES_SIGNAL_ALLOWED_USERS}
       HERMES_YOLO_MODE: "1"
+      HERMES_WRITE_SAFE_ROOT: /opt/data:/tmp
 
     # Secrets rendered into a Kubernetes Secret by the chart
     secrets:


### PR DESCRIPTION
## Problem
The Hermes Agent Dockerfile sets HERMES_WRITE_SAFE_ROOT=/opt/data, which causes the write_file and patch tools to reject writes to /tmp.

The terminal tool works fine (touch /tmp/foo succeeds), but file-level tools are blocked with: Write denied: protected system/credential file.

## Root Cause
agent/file_safety.py is_write_denied(): when HERMES_WRITE_SAFE_ROOT is set, writes outside those roots are denied. /tmp is not in the safe roots.

## Fix
Add /tmp to HERMES_WRITE_SAFE_ROOT in the HelmRelease values.

Note: /tmp is already mounted as a writable emptyDir in the chart — the Kubernetes-level volume is fine. The block is purely the Hermes tool guard.