### PR TITLE
fix(monitoring): Prometheus retentionSize must use GiB suffix for operator v87 schema

### DIFF
--- a/platform/monitoring/prometheus-stack.yaml
+++ b/platform/monitoring/prometheus-stack.yaml
@@ -107,7 +107,7 @@ spec:
         # Cap TSDB size so Prometheus self-manages retention; the PVC is
         # sized with ~15% headroom above this to absorb WAL overhead and
         # compaction spikes without hitting ENOSPC.
-        retentionSize: 55Gi
+        retentionSize: 55GiB
         storageSpec:
           volumeClaimTemplate:
             metadata:


### PR DESCRIPTION
## What

Fix `retentionSize: 55Gi` → `retentionSize: 55GiB` in the kube-prometheus-stack HelmRelease values.

## Why

The kube-prometheus-stack chart upgrade to v87.5.1 fails with:

```
Prometheus.monitoring.coreos.com "kube-prometheus-stack" is invalid:
spec.retentionSize: Invalid value: "55Gi":
spec.retentionSize in body should match
'(^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$'
```

The Prometheus operator CRD schema was tightened in v87 to require the `B` suffix on `retentionSize` values.

## Impact

- HelmRelease `monitoring/kube-prometheus-stack` currently stuck as `UpgradeFailed` with `RetriesExceeded`
- After merge, Flux will upgrade the chart, which includes PVC resize from 16Gi → 64Gi
- The Prometheus pod is **also** crash-looping independently (PVC is full — `no space left on device`) — that requires manual intervention (resize Longhorn volume before or after this merges)