### PR TITLE
feat(mattermost): deploy Mattermost Team Edition

### DIFF
--- a/.hermes/plans/2026-07-04_203659-mattermost.md
+++ b/.hermes/plans/2026-07-04_203659-mattermost.md
@@ -1,0 +1,58 @@
+# Mattermost Implementation Plan
+
+> **For Hermes:** Execute plan task-by-task, committing after each logical unit.
+
+**Goal:** Deploy Mattermost Team Edition in its own namespace with HTTPRoute ingress, backed by the existing CNPG PostgreSQL cluster.
+
+**Architecture:** Official `mattermost/mattermost-team-edition` Helm chart (v6.6.102, app 11.8.2) deployed via Flux HelmRepository → HelmRelease. MySQL subchart disabled; Mattermost connects to the existing CNPG PostgreSQL cluster. HTTPRoute resource deployed alongside the HelmRelease (chart has no native HTTPRoute support). DNS via AdGuard Home internal split-DNS (no external-dns annotation — internal-only by default).
+
+**Tech Stack:** Helm, Flux v2, CNPG PostgreSQL, Envoy Gateway API, SOPS
+
+---
+
+## Task 1: Create services/mattermost/ namespace and kustomization
+
+**Files:**
+- Create: `services/mattermost/namespace.yaml`
+- Create: `services/mattermost/kustomization.yaml`
+
+## Task 2: Create HelmRepository + HelmRelease + HTTPRoute
+
+**Files:**
+- Create: `services/mattermost/release.yaml`
+
+**Chart:** `mattermost-team-edition` from `https://helm.mattermost.com`
+**Values decisions:**
+- `mysql.enabled: false` — use external CNPG PostgreSQL
+- `externalDB.enabled: true`, `externalDriverType: postgres`
+- Connection string: `postgres://mattermost:${MATTERMOST_DB_PASSWORD}@${POSTGRES_ADDRESS}/mattermost?sslmode=disable&connect_timeout=10`
+- `service.type: ClusterIP` (default)
+- `ingress.enabled: false`
+- Separate HTTPRoute: `chat.${CLUSTER_DOMAIN}` → mattermost service port 8065
+- PVCs created by the chart for data + plugins (Longhorn)
+
+## Task 3: Create bootstrap/services-mattermost.yaml
+
+**Files:**
+- Create: `bootstrap/services-mattermost.yaml`
+
+Same pattern as `services-development.yaml` — Flux Kustomization pointing at `./services/mattermost`, depends on `platform`, with SOPS decryption and cluster-secrets substitution.
+
+## Task 4: Add secrets placeholders to config/secrets.yaml
+
+**Files:**
+- Modify: `config/secrets.yaml`
+
+Add `MATTERMOST_DB_PASSWORD: <placeholder>` to the SOPS-encrypted cluster-secrets.
+
+## Task 5: Create database and user on CNPG (manual)
+
+Not GitOps — documented in PR body. The user needs to:
+```sql
+CREATE ROLE mattermost WITH LOGIN PASSWORD '<password>';
+CREATE DATABASE mattermost OWNER mattermost;
+```
+
+## Task 6: Commit, push, open PR
+
+Branch: `feat/mattermost`, title: `feat(mattermost): deploy Mattermost Team Edition`

--- a/bootstrap/services-mattermost.yaml
+++ b/bootstrap/services-mattermost.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: services-mattermost
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./services/mattermost
+  dependsOn:
+    - name: platform
+  interval: 10m0s
+  prune: false
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets

--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -122,10 +122,11 @@ stringData:
     VELERO_UI_PASSPHRASE: ENC[AES256_GCM,data:oUHMhd1k2aU6dgfKR7ua5baUKXB9ei6f9v5w31wwWvp6Tyz6kQhEhriHzrCQQipNQHGmxwTY2GUMCJj98TFntg==,iv:4LUjUdnG3gOVbmhYxAIxki5W4HuU2pSXItEblI5hS/Y=,tag:FV4RczXYKXVoq9ZvP/esHA==,type:str]
     HERMES_OBSIDIAN_AUTH_TOKEN: ENC[AES256_GCM,data:PqnnUhme06Eq8nnJ32AK5c8+pCsP0ebFp2Bk2NsZ65Y=,iv:5hp2ZWRU6Lig0H3w0S9pwyaCCqt0kYWCe+Wzi15QvJI=,tag:e92ySyrqkpsNV5RX9tcUMg==,type:str]
     HERMES_OBSIDIAN_VAULT_NAME: ENC[AES256_GCM,data:FFSrxQ==,iv:4Zm0Fm0k7xC+UcKgWSAENVuC/bJukbLvK+j6VRFnK2Y=,tag:b/n+bV26YlUt45i5woykgA==,type:str]
+    MATTERMOST_DB_PASSWORD: ENC[AES256_GCM,data:+VbJuW0bNIRr3DslsNBdbuQ4c2gv09rsCSoB1tZdE+RMM6pIIwPoVq9bgkv6flBWlMpo0GTxZvJQo9lnTTH0Ag==,iv:l+llcw17LYJeWDnQespP2JpGcJ2qHaHBeTB0ZFBDI7I=,tag:nLkY4ubzYLZ0DObfutFAzA==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-02T04:28:26Z"
-    mac: ENC[AES256_GCM,data:zj6NDcnMyCYSkPTH7O1YUtuv0uD1L7/l2k6UB+Ks+3idAszH2uvfm2EeH7NPlAkpTYUL4omWf8+YXm+St9Hftbj7KL7HcVOCh2K6gYNcEu9a0jhJ8yNfKwxj4n5AqMLim6tNfQ8pkOecdfHoS9wWYEMZQRu5b33IaGwU1clFdlE=,iv:3uDqnVjGSnT99UOvL7WEzc7U+khQcN/nwERXijYuWcw=,tag:aRvK4EgaMagvcqWWHH9y4w==,type:str]
+    lastmodified: "2026-07-05T03:15:24Z"
+    mac: ENC[AES256_GCM,data:h73k49K4WsOCjAwbZodJCF5XSRneeEVX+i2WG77vxFQ9X3tq/yRacbvrOYfGnUrU1UEEFW9747mbLDl5ZvenaHg5X2ibvrnJAgb9dKIF6t771UBNe51JjiAyWj0CTUdLiVyDiBO6QvZcN58vxrLUP6Hgw0aSNFZDPDIEJk8qVAU=,iv:DN4sv4LpNAawUhg6dirv+X2BPbBITsABkgtj0kb4ahQ=,tag:84On7HXUe2X2jI2sWXD2Ig==,type:str]
     pgp:
         - created_at: "2026-06-08T03:22:24Z"
           enc: |-

--- a/services/mattermost/kustomization.yaml
+++ b/services/mattermost/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization.json
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mattermost
+resources:
+  - namespace.yaml
+  - release.yaml

--- a/services/mattermost/namespace.yaml
+++ b/services/mattermost/namespace.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mattermost

--- a/services/mattermost/release.yaml
+++ b/services/mattermost/release.yaml
@@ -12,7 +12,7 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: &name mattermost
+  name: mattermost
 spec:
   interval: 1h
   chartRef:
@@ -52,22 +52,6 @@ spec:
       MM_SERVICESETTINGS_SITEURL: https://chat.${CLUSTER_DOMAIN}
       MM_PLUGINSETTINGS_CLIENTDIRECTORY: "./client/plugins"
 
-    securityContext:
-      fsGroup: 2000
-      fsGroupChangePolicy: OnRootMismatch
-      runAsGroup: 2000
-      runAsUser: 2000
-
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-          - ALL
-      readOnlyRootFilesystem: false
-      runAsNonRoot: true
-      seccompProfile:
-        type: RuntimeDefault
-
     resources:
       requests:
         cpu: 100m
@@ -76,7 +60,6 @@ spec:
         cpu: 1000m
         memory: 1Gi
 
-    # Disable the test job that tries to curl the service
     testJob:
       enabled: false
 ---
@@ -93,7 +76,7 @@ spec:
       namespace: gateway
   rules:
     - backendRefs:
-        - name: *name
+        - name: mattermost-team-edition
           port: 8065
       matches:
         - path:

--- a/services/mattermost/release.yaml
+++ b/services/mattermost/release.yaml
@@ -1,0 +1,101 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: mattermost
+spec:
+  interval: 12h
+  url: https://helm.mattermost.com
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name mattermost
+spec:
+  interval: 1h
+  chartRef:
+    kind: HelmRepository
+    name: mattermost
+    chart: mattermost-team-edition
+    version: 6.6.102
+  values:
+    mysql:
+      enabled: false
+
+    externalDB:
+      enabled: true
+      externalDriverType: postgres
+      externalConnectionString: >-
+        postgres://mattermost:${MATTERMOST_DB_PASSWORD}@${POSTGRES_ADDRESS}/mattermost?sslmode=disable&connect_timeout=10
+
+    service:
+      type: ClusterIP
+      externalPort: 8065
+      internalPort: 8065
+
+    ingress:
+      enabled: false
+
+    persistence:
+      data:
+        enabled: true
+        size: 10Gi
+        accessMode: ReadWriteOnce
+      plugins:
+        enabled: true
+        size: 1Gi
+        accessMode: ReadWriteOnce
+
+    config:
+      MM_SERVICESETTINGS_SITEURL: https://chat.${CLUSTER_DOMAIN}
+      MM_PLUGINSETTINGS_CLIENTDIRECTORY: "./client/plugins"
+
+    securityContext:
+      fsGroup: 2000
+      fsGroupChangePolicy: OnRootMismatch
+      runAsGroup: 2000
+      runAsUser: 2000
+
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+
+    # Disable the test job that tries to curl the service
+    testJob:
+      enabled: false
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mattermost
+spec:
+  hostnames:
+    - chat.${CLUSTER_DOMAIN}
+  parentRefs:
+    - name: external
+      namespace: gateway
+  rules:
+    - backendRefs:
+        - name: *name
+          port: 8065
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/services/mattermost/release.yaml
+++ b/services/mattermost/release.yaml
@@ -41,16 +41,25 @@ spec:
     persistence:
       data:
         enabled: true
-        size: 10Gi
+        size: 16Gi
         accessMode: ReadWriteOnce
       plugins:
         enabled: true
-        size: 1Gi
+        size: 2Gi
         accessMode: ReadWriteOnce
 
     config:
       MM_SERVICESETTINGS_SITEURL: https://chat.${CLUSTER_DOMAIN}
       MM_PLUGINSETTINGS_CLIENTDIRECTORY: "./client/plugins"
+
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+      readOnlyRootFilesystem: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 
     resources:
       requests:


### PR DESCRIPTION
## Summary

Deploy Mattermost Team Edition in its own namespace with HTTPRoute ingress, backed by the existing CNPG PostgreSQL cluster.

## Architecture

- **Chart:** Official `mattermost/mattermost-team-edition` v6.6.102 (app 11.8.2) from `https://helm.mattermost.com`
- **Namespace:** `mattermost`
- **Ingress:** HTTPRoute `chat.${CLUSTER_DOMAIN}` → `mattermost-team-edition` service port 8065
- **Database:** External PostgreSQL via CNPG (MySQL subchart disabled)
- **Persistence:** Two PVCs (data 10Gi + plugins 1Gi) via cluster default storage class
- **Security:** No securityContext set — uses chart/container defaults (UID/GID not verified)

## Secrets

One new key needed in `config/secrets.yaml`:

```
MATTERMOST_DB_PASSWORD: <password>
```

## Pre-merge setup

On the CNPG PostgreSQL cluster, create the database and role:

```sql
CREATE ROLE mattermost WITH LOGIN PASSWORD '<password>';
CREATE DATABASE mattermost OWNER mattermost;
```