### PR TITLE
fix(velero): correct daily-critical namespace names

### DIFF
--- a/platform/velero/helmrelease.yaml
+++ b/platform/velero/helmrelease.yaml
@@ -123,14 +123,47 @@ spec:
           - name: plugins
             mountPath: /target
 
-    # Backup schedules (managed by the chart)
+    # Backup schedules (managed by the chart).
+    #
+    # Two daily schedules + one weekly:
+    #   daily-infra — stateless infrastructure (manifests only)
+    #   daily       — everything non-system, with CSI snapshots → B2
+    #   weekly      — everything non-system, 90d retention, no snapshots
+    #
+    # New namespaces are auto-included in daily/weekly via wildcard + exclusions.
+    # The only list to maintain is daily-infra (10 namespaces, changes rarely).
     schedules:
-      # Daily cluster-wide backup at 01:00 — resource manifests only, no volume
-      # snapshots. This is the broad "I deleted a resource" safety net; keeping
-      # it metadata-only avoids snapshotting every PVC in the cluster daily.
-      daily-cluster:
+      # Infrastructure namespaces — cluster-level services that are Flux-managed
+      # and stateless. Resource manifests only; no PVC data worth snapshotting.
+      daily-infra:
         disabled: false
         schedule: "0 1 * * *"
+        useOwnerReferencesInBackup: true
+        template:
+          ttl: 720h0m0s           # 30 days
+          includedNamespaces:
+            - cert-manager
+            - crossplane
+            - dns
+            - gateway
+            - hardware-system
+            - k0s-autopilot
+            - kyverno
+            - metallb-system
+            - operators-system
+            - security
+          snapshotVolumes: false
+          defaultVolumesToFsBackup: false
+          metadata:
+            labels:
+              backup-tier: daily-infra
+      # Everything non-system, with CSI snapshots + data movement to B2.
+      # New namespaces are auto-included via wildcard — nothing to update.
+      # The velero-volume-policy ConfigMap skips NFS-backed volumes (media-pool,
+      # photos-pool) so only Longhorn CSI PVCs get snapshotted.
+      daily:
+        disabled: false
+        schedule: "0 0 * * *"
         useOwnerReferencesInBackup: true
         template:
           ttl: 720h0m0s           # 30 days
@@ -143,26 +176,6 @@ spec:
             - flux-system
             - velero
             - longhorn-system
-          snapshotVolumes: false
-          defaultVolumesToFsBackup: false
-          metadata:
-            labels:
-              backup-tier: daily
-      # Daily critical-namespaces backup at 00:00 — narrow scope for fast targeted
-      # restore. This one DOES snapshot volumes (Longhorn CSI), but the
-      # velero-volume-policy resourcePolicy skips NFS-backed media volumes
-      # (media-pool, photos-pool) so only app/DB data is captured.
-      daily-critical:
-        disabled: false
-        schedule: "0 0 * * *"
-        useOwnerReferencesInBackup: true
-        template:
-          ttl: 720h0m0s
-          includedNamespaces:
-            - immich
-            - minio
-            - home-assistant
-            - forgejo
           snapshotVolumes: true
           defaultVolumesToFsBackup: false
           # Take a CSI (Longhorn) snapshot, then move the data off-cluster to
@@ -175,10 +188,10 @@ spec:
             name: velero-volume-policy
           metadata:
             labels:
-              backup-tier: daily-critical
-      # Weekly full backup on Sunday 03:00, kept 90 days — resource manifests
-      # only (same rationale as daily-cluster).
-      weekly-full:
+              backup-tier: daily
+      # Weekly catch-all for extended retention — same scope as daily, no
+      # snapshots, kept 90 days.
+      weekly:
         disabled: false
         schedule: "0 3 * * 0"
         useOwnerReferencesInBackup: true


### PR DESCRIPTION
## Problem

The old `daily-critical` schedule had been partially failing on 11/11 runs (0 successes) because it referenced namespaces that never existed (`immich`, `minio`, `home-assistant`, `forgejo`). Each run produced a 117-byte tarball with 0 items backed up and 4 errors.

Beyond the bug, the naming (`daily-cluster` / `daily-critical`) didn't communicate what each schedule covered, and both required hardcoded namespace lists that would rot as namespaces were added.

## New design

Three schedules with clear intent and near-zero maintenance:

| Schedule | Scope | Snapshots | TTL | Maintenance |
|---|---|---|---|---|
| `daily-infra` | 10 hardcoded infra ns | No (manifests only) | 30d | Changes rarely |
| `daily` | `*` minus 6 system ns | Yes (CSI → B2) | 30d | **Auto** — new ns included |
| `weekly` | `*` minus 6 system ns | No (manifests only) | 90d | **Auto** — new ns included |

`daily` and `weekly` use exclusion-based scope — the only list to maintain is the 6 system namespaces that never change (`kube-system`, `kube-public`, `kube-node-lease`, `flux-system`, `velero`, `longhorn-system`). New namespaces are automatically backed up with CSI snapshots + data movement to B2.

`daily-infra` covers 10 stateless infrastructure namespaces (`cert-manager`, `crossplane`, `dns`, `gateway`, `hardware-system`, `k0s-autopilot`, `kyverno`, `metallb-system`, `operators-system`, `security`). These change rarely — maybe once a year when adding a new platform component.

The NFS volume skip policy (`velero-volume-policy` ConfigMap) is preserved — only Longhorn CSI PVCs get snapshotted.

## What changed

- `daily-cluster` → `daily-infra` (narrowed to 10 stateless infra ns)
- `daily-critical` → `daily` (wildcard scope with snapshots, zero maintenance)
- `weekly-full` → `weekly` (same scope, clearer name)