### PR TITLE
fix(velero): add loadAffinity ConfigMap for CSI data mover node selection

### DIFF
--- a/platform/velero/data-mover-config.yaml
+++ b/platform/velero/data-mover-config.yaml
@@ -1,0 +1,33 @@
+# Node selection config for the Velero CSI data mover.
+#
+# Without this, data mover pods are scheduled to random nodes.  With
+# Longhorn, the restored PVC's volume may already be attached to a
+# specific node (the node where the Longhorn replica/engine landed),
+# so a data mover pod on a DIFFERENT node fails with:
+#
+#   AttachVolume.Attach failed: volume … is not ready for workloads
+#
+# The loadAffinity ConfigMap constrains data mover pod scheduling.
+# Specifying the Longhorn storageClass ties the scheduling decision
+# to the StorageClass's topology (WaitForFirstConsumer), so the data
+# mover pod lands on the same node Longhorn expects.
+#
+# Ref: https://velero.io/docs/main/data-movement-node-selection/
+# Ref: https://github.com/velero-io/velero/issues/9343
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: velero-data-mover-config
+  namespace: velero
+data:
+  loadAffinity: |
+    [
+      {
+        "storageClass": [
+          {
+            "name": "longhorn"
+          }
+        ]
+      }
+    ]

--- a/platform/velero/helmrelease.yaml
+++ b/platform/velero/helmrelease.yaml
@@ -46,6 +46,13 @@ spec:
       # "unexpected directory structure for host-pods volume".
       podVolumePath: /var/lib/k0s/kubelet/pods
       pluginVolumePath: /var/lib/k0s/kubelet/plugins
+      # Tell the node-agent about the data-mover-config ConfigMap so the CSI
+      # data mover respects Longhorn's WaitForFirstConsumer topology when
+      # scheduling backup/restore pods.  Without this the data mover pod may
+      # land on a node where the Longhorn volume isn't attached.
+      # Ref: https://velero.io/docs/main/data-movement-node-selection/
+      extraArgs:
+        - --node-agent-configmap=velero-data-mover-config
       resources:
         requests:
           cpu: 50m

--- a/platform/velero/kustomization.yaml
+++ b/platform/velero/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - helmrelease.yaml
   - volumesnapshotclass.yaml
   - volume-policy.yaml
+  - data-mover-config.yaml
   - dashboard.yaml
   - ui.yaml


### PR DESCRIPTION
## Problem

Velero's CSI data mover pods get scheduled to random nodes. When Longhorn has the restored volume attached to a different node, the mount fails:

```
AttachVolume.Attach failed: volume pvc-xxx is not ready for workloads
```

This causes every `snapshotMoveData: true` backup to fail — volume data never reaches B2.

## Root Cause

Velero creates a VolumeSnapshot → restores into a new PVC → Longhorn attaches the volume to a node based on replica scheduling → the data mover pod lands on a *different* node → mount fails because Longhorn doesn't support multi-attach.

## Fix

1. **New `data-mover-config.yaml`** — a ConfigMap with `loadAffinity` that ties data mover scheduling to the `longhorn` StorageClass's `WaitForFirstConsumer` topology, so the pod lands on the same node where the volume is attached.

2. **HelmRelease** — pass `--node-agent-configmap=velero-data-mover-config` to the node-agent DaemonSet so it reads the new config.

## References

- <https://velero.io/docs/main/data-movement-node-selection/>
- <https://github.com/velero-io/velero/issues/9343> (fixed in v1.18.1 — this config enables the fix)