### PR TITLE
feat(config): disable k0s-managed CNI and kube-proxy for Cilium

### DIFF
--- a/config/cluster.yaml
+++ b/config/cluster.yaml
@@ -27,6 +27,9 @@ spec:
         user: root
         port: 22
   k0s:
+    # NOTE: pinned to v1.35.3+k0s.0 here but the cluster currently runs
+    # v1.36.2. Update this field separately to align the k0sctl spec
+    # with the live cluster version. Tracked as a follow-up.
     version: v1.35.3+k0s.0
     config:
       apiVersion: k0s.k0sproject.io/v1beta1
@@ -35,10 +38,11 @@ spec:
         name: k0s-inwin
       spec:
         network:
+          # Custom CNI provider — Cilium is installed via GitOps (core/cilium.yaml)
+          # and manages the CNI, kube-proxy replacement, and service load balancing.
+          provider: custom
           kubeProxy:
-            mode: ipvs
-            ipvs:
-              strictARP: true
-          nodeLocalLoadBalancing:
-            enabled: true
-            type: EnvoyProxy
+            disabled: true
+          # nodeLocalLoadBalancing was previously enabled (type: EnvoyProxy)
+          # and is intentionally removed: Cilium handles service load balancing
+          # via kube-proxy replacement, so k0s-managed Envoy NLLB would conflict.


### PR DESCRIPTION
## Summary

Switches the k0sctl cluster spec (`config/cluster.yaml`) to a custom CNI provider so k0s stops managing kube-router and kube-proxy, clearing the way for Cilium to own the CNI, kube-proxy replacement, and service load balancing.

This is the **k0s cluster config portion** of the Cilium migration, split into its own PR for focused review.

### Changes (`config/cluster.yaml` only)
- `spec.network.provider: custom` — k0s no longer manages the kube-router CNI. Cilium is installed via GitOps (`core/cilium.yaml`) and handles CNI + kube-proxy replacement + service LB.
- `spec.network.kubeProxy: disabled: true` — removed the prior `mode: ipvs` / `ipvs.strictARP: true` block (Cilium's eBPF kube-proxy replacement supersedes it).
- `spec.network.nodeLocalLoadBalancing` — removed entirely (was `type: EnvoyProxy`). Cilium handles service load balancing via kube-proxy replacement, so k0s-managed Envoy NLLB would conflict.
- NOTE comment on `k0s.version`: spec pins `v1.35.3+k0s.0` but the live cluster runs `v1.36.2` — flagged as a separate follow-up.

No other k0s settings (hosts, SSH, storage, API server args, metadata) are touched.

## Migration context

Part of the broader Cilium migration (`feat/cilium-hubble`). The Cilium HelmRelease, BGP/IPAM resources, and Gateway API changes live in the companion branch. This PR only touches the k0sctl spec so the cluster-config change can be reviewed and applied independently.

## Verification
- YAML parses cleanly (validated with `yaml.safe_load`).
- Confirmed `provider=custom`, `kubeProxy={'disabled': True}`, `nodeLocalLoadBalancing` absent.
- Diff is scoped to `config/cluster.yaml` — 1 file changed, 10 insertions(+), 6 deletions(-).

## Migration path (post-merge)
1. Apply the new k0sctl config per node with `k0sctl apply --config config/cluster.yaml` (drain + apply).
2. Remove the kube-router DaemonSet manually (cluster runs with `prune: false`).
3. Install/verify Cilium via the companion branch.

> Note: the `k0s.version` field is out of sync with the live cluster (`v1.35.3+k0s.0` in spec vs `v1.36.2` running). This is left as-is here and tracked as a separate follow-up — do not bump it as part of this PR.
