### PR TITLE
feat(core): add Istio ambient mode HelmReleases and ztunnel manifests

### DIFF
--- a/.hermes/plans/istio-ambient-mesh.md
+++ b/.hermes/plans/istio-ambient-mesh.md
@@ -1,0 +1,703 @@
+# Istio Ambient Mode Service Mesh — Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development to implement this plan task-by-task.
+> This is a **draft PR** — not for merging. Goal is a working configuration + documented findings.
+> If Istio ambient conflicts with any existing component, document the conflict and stop.
+
+**Goal:** Add Istio ambient mode (ztunnel + waypoint) to the homelab k8s cluster via GitOps, enabling mTLS and L4 observability for selected namespaces without sidecar injection.
+
+---
+
+## 1. Architecture Overview
+
+### What ambient mode is
+
+Istio ambient mode replaces the per-pod Envoy sidecar with a two-layer data plane:
+
+1. **ztunnel** — a node-local DaemonSet (Rust) that runs one logical proxy per pod. It handles L4 traffic: mTLS termination, AuthorizationPolicy (L4), and TCP metrics. ztunnel operates *inside each pod's network namespace* (not at the host level), listening on ports 15008 (HBONE), 15006 (inbound), 15001 (outbound).
+2. **waypoint proxy** — an optional Envoy-based deployment (one per namespace or per service) that handles L7 policy (AuthorizationPolicy L7, RequestAuthentication, WasmPlugin, L7 Telemetry, HTTPRoute-based traffic routing). Waypoints are opt-in per namespace via the `istio.io/use-waypoint` label.
+
+### Traffic flow
+
+```
+Pod A (meshed) --> [pod netns: iptables redirect] --> ztunnel (node-local)
+                                                          |
+                                                    HBONE tunnel (mTLS)
+                                                          |
+Pod B (meshed) <-- [pod netns: iptables redirect] <-- ztunnel (node-local)
+
+With waypoint:
+Pod A --> ztunnel --HBONE--> waypoint --HBONE--> ztunnel --> Pod B
+```
+
+- **HBONE** (HTTP-Based Overlay Network Environment) is Istio's tunneling protocol: HTTP/2 CONNECT over mTLS, carrying the original TCP stream. This is how ztunnel-to-ztunnel and ztunnel-to-waypoint traffic is encrypted.
+- Traffic between two meshed pods is always mTLS-encrypted via HBONE. Traffic from an unmeshed source to a meshed destination arrives as plaintext (ztunnel accepts both, but AuthorizationPolicy can require an identity to block plaintext).
+- ztunnel manages certificates *on behalf of* the pods on its node — one cert per unique service account identity. The CA (Istiod) enforces that ztunnel may only request certs for identities actually running on that node (via K8s SA JWT token validation).
+
+### How traffic redirection works (critical for CNI coexistence)
+
+Ambient mode uses an **in-pod traffic redirection** model, NOT node-level eBPF:
+
+1. The **istio-cni** node agent installs a *chained CNI plugin* that runs after the primary CNI (kube-router today, Cilium in the planned migration). It is notified on pod creation in ambient-enabled namespaces.
+2. `istio-cni` enters the pod's network namespace and sets up iptables/nftables redirection rules so all pod ingress/egress goes to ztunnel's listening ports (15008/15006/15001).
+3. `istio-cni` passes the pod's network namespace file descriptor to ztunnel over a Unix domain socket (`/var/run/ztunnel/ztunnel.sock`). ztunnel then creates listening sockets *inside the pod's network namespace* — the proxy runs in the ztunnel process but operates within each pod's netns.
+4. The pod's application is completely unaware of the tunnel; all encryption and policy enforcement happens transparently.
+
+**Key insight:** Because redirection happens at the pod network namespace level (via a chained CNI plugin + iptables inside the pod netns), ambient mode is **CNI-agnostic by design**. It does not compete with the primary CNI at the node/host level. See section 3 (Cilium interaction) for details.
+
+### Component inventory (4 Helm charts)
+
+| Chart | Purpose | Deployment type | Default resources |
+|-------|---------|-----------------|-------------------|
+| `istio/base` | CRDs + cluster roles (Prereq for all others) | — | — |
+| `istio/istiod` | Control plane (istiod), configured with `profile: ambient` | Deployment (1 replica, HPA 1-5) | 500m CPU / 2048Mi mem request |
+| `istio/cni` | CNI node agent + chained plugin, `profile: ambient` | DaemonSet (all nodes) | 100m CPU / 100Mi mem request |
+| `istio/ztunnel` | L4 data plane proxy | DaemonSet (all nodes) | 200m CPU / 512Mi mem request |
+
+No `istio/gateway` chart is needed — the cluster already uses Envoy Gateway for ingress, and Istio ambient's Gateway API integration is optional (we are not replacing the existing ingress).
+
+---
+
+## 2. Current Cluster State (findings from probe)
+
+### Nodes and Kubernetes
+
+- 3 nodes: `k0s-inwin-01/02/03`, all `control-plane` (controller+worker, no taints)
+- Kubernetes v1.36.2+k0s — within Istio 1.30's supported range (1.32-1.36)
+- k0s v1.35.3 in `config/cluster.yaml` (stale — cluster runs 1.36.2; noted in Cilium task pitfalls)
+
+### Current CNI / networking stack (what ambient must coexist with)
+
+| Component | Location | Notes |
+|-----------|----------|-------|
+| **kube-router** (CNI) | DaemonSet in `kube-system` | Current CNI; Cilium migration is sibling task `t_e6b0051f` |
+| **kube-proxy** (IPVS, strictARP) | DaemonSet in `kube-system` | k0s-managed; Cilium eBPF replacement planned |
+| **MetalLB** (FRR/BGP) | `metallb-system` namespace | `metallb-frr-k8s` + `metallb-speaker` DaemonSets; Cilium BGP planned |
+| **Envoy Gateway** | `gateway` namespace | Gateway API controller, `GatewayClass: envoy`; Cilium Gateway API planned |
+| **k0s nodeLocalLoadBalancing** | `config/cluster.yaml` | EnvoyProxy type; may conflict with Cilium per Cilium task notes |
+
+**Cilium status:** The Cilium migration (`t_e6b0051f`) is **blocked** — it has been attempted 8 times and given up twice due to iteration budget exhaustion. No Cilium manifests exist in `main` or on the `feat/cilium-hubble` branch (the branch is at the same HEAD as main). **Ambient mode must be designed to work with the current kube-router CNI, and also be compatible with a future Cilium CNI.** The good news: ambient's in-pod redirection model is CNI-agnostic (section 1, section 3).
+
+### cert-manager
+
+- cert-manager v1.20.3 (chart) / OCI from `quay.io/jetstack/charts/cert-manager`
+- **Both ClusterIssuers use DNS-01 via Cloudflare** (not HTTP-01):
+  - `letsencrypt` (prod) and `letsencrypt-staging` both use `dns01.cloudflare.apiTokenSecretRef`
+- DNS-01 is mesh-safe: cert-manager's ACME solver doesn't receive inbound HTTP traffic, so mesh redirection cannot break certificate issuance/renewal. **No cert-manager changes needed.**
+
+### Envoy Gateway (potential conflict surface)
+
+- `GatewayClass: envoy` (controller: `gateway.envoyproxy.io/gatewayclass-controller`)
+- `Gateway: external` in `gateway` namespace, listeners on :80 and :443
+- HTTPRoutes across many service namespaces attach to `external` gateway
+- **Conflict analysis with Istio:**
+  - **Gateway class:** Istio's Gateway API controller (if enabled) uses a *different* GatewayClass (`istio` / controller `istio.io/gateway-controller`). Envoy Gateway uses `envoy`. No collision — they manage different GatewayClasses. We will **not** install the `istio/gateway` chart, so Istio's Gateway API controller is not deployed; no conflict at all.
+  - **Envoy in both:** Envoy Gateway runs Envoy for ingress; ztunnel is Rust (not Envoy); waypoints are Envoy but deployed as separate pods in meshed namespaces. No shared processes or ports.
+  - **CRDs:** Both consume Gateway API CRDs (`gateway.networking.k8s.io`). The cluster already has these CRDs (Envoy Gateway installed them). Istio ambient does not reinstall Gateway API CRDs unless we opt into the Gateway chart — we won't. **No CRD ownership conflict.**
+  - **HTTPRoutes:** Existing HTTPRoutes reference `parentRefs: [{name: external, namespace: gateway}]` (Envoy Gateway). These do NOT need `istio.io/rev` annotations — they route to Envoy Gateway, not Istio. The only resources that need Istio annotations are ones we *want* in the mesh.
+
+### Namespaces and workloads (mesh opt-in candidates)
+
+26 namespaces on cluster. Grouped by mesh suitability:
+
+**System / infrastructure — EXCLUDE from mesh:**
+| Namespace | Why exclude |
+|-----------|------------|
+| `kube-system` | System pods, CNI, konnectivity, coredns, metrics-server, reloader, k8tz, snapshot-controller — must not be disrupted |
+| `kube-public`, `kube-node-lease` | System, no workloads |
+| `flux-system` | GitOps controller — must not be meshed (could break reconciliation) |
+| `k0s-autopilot` | k0s system |
+| `metallb-system` | Load balancer infra — meshing the LB speaker risks breaking BGP/routing |
+| `longhorn-system` | Storage CSI — meshing CSI pods risks breaking volume operations |
+| `hardware-system` | Node feature discovery, GPU plugin — node-level, no benefit |
+| `cert-manager` | ACME solver uses DNS-01 (safe), but no benefit from meshing; exclude to avoid any cert renewal risk |
+| `operators-system` | Operator controllers (CNPG, Strimzi, Dragonfly, Grafana operators) — these manage other namespaces' CRDs; meshing could add latency to control loops |
+| `crossplane` | Crossplane providers manage external infra; exclude |
+| `velero` | Backup system, privileged PSA — exclude to avoid backup disruption |
+| `kyverno` | Policy controller — exclude (admission webhooks must not be delayed) |
+| `gateway` | Envoy Gateway controller + data plane — exclude (ingress must stay direct) |
+| `dns` | ExternalDNS (AdGuard + Cloudflare) — exclude; DNS record updates must not be tunneled |
+
+**Platform services — CANDIDATES for mesh (Phase 2, after stability validation):**
+| Namespace | Workload | Mesh benefit |
+|-----------|----------|--------------|
+| `database` | CNPG PostgreSQL 18, Strimzi Kafka | mTLS for DB connections, L4 authz (but see section 4 risks — DB/Kafka may need plaintext fallback) |
+| `garage` | Garage S3 + webui | mTLS for internal S3 calls |
+| `monitoring` | Grafana, Prometheus, Loki, Promtail, Alertmanager, KSM | mTLS for scraping; but Prometheus scraping may need plaintext (see section 4) |
+| `security` | pocket-id, oauth2-proxy, tinyauth | mTLS for auth flows |
+
+**Application services — PRIMARY mesh candidates (Phase 1):**
+| Namespace | Workload | Mesh benefit |
+|-----------|----------|--------------|
+| `automation` | hermes-agent, home-assistant, zwave-js-ui, signal-cli-rest-api, frigate | mTLS between automation services; L4 telemetry |
+| `development` | forgejo | mTLS for internal git/CI calls |
+| `general` | vaultwarden, actual | mTLS for secrets manager access |
+| `media` | plex, sonarr, radarr, sabnzbd, ersatztv, sonarr-anime | mTLS between media services (arr stack) |
+| `immich` | immich | mTLS |
+| `mattermost` | mattermost-team-edition | mTLS |
+| `api` | cloudstream | mTLS |
+
+**Other:**
+| Namespace | Notes |
+|-----------|-------|
+| `actual` | Namespace for Actual budget (workload in `general`? — probe shows `actual/actual` deployment) |
+| `default` | Only `iperf-server` — exclude (test workload) |
+
+### Recommended opt-in strategy
+
+**Phase 1 (this PR — validate ambient works):**
+- Label `automation`, `media`, `development` with `istio.io/dataplane-mode: ambient`
+- These are the most interconnected service-to-service workloads (arr stack, automation chain)
+- No waypoints yet — L4 mTLS only
+
+**Phase 2 (follow-up, after Phase 1 is stable for 1 week):**
+- Add `general`, `immich`, `mattermost`, `api`, `security`
+- Optionally add waypoints for namespaces needing L7 policy (e.g., `security` for authz rules)
+
+**Excluded permanently:** All system/infra namespaces in the table above.
+
+---
+
+## 3. Cilium / CNI Interaction
+
+### Current state: kube-router (no Cilium yet)
+
+Today the CNI is kube-router (a BGP-based CNI). Istio's `istio-cni` chained plugin will run after kube-router in the CNI chain. This is the standard, supported configuration — the Istio docs describe the chained CNI plugin as the ambient traffic redirection mechanism, and it works with any CNI.
+
+k0s manages kube-router and kube-proxy as system components. The `istio-cni` DaemonSet needs:
+- `cniBinDir: /opt/cni/bin` (k0s default — verify on node)
+- `cniConfDir: /etc/cni/net.d` (k0s default — verify on node)
+- `chained: true` (default — appends to the existing CNI config file rather than replacing it)
+
+**Risk:** k0s may overwrite CNI config files on restart (k0s manages the CNI). If k0s regenerates `/etc/cni/net.d/*.conf`, the istio-cni chained plugin entry may be lost. Mitigation: verify the chained plugin persists across k0s restarts during Phase 1 validation. If k0s overwrites it, the istio-cni agent has a reconciliation loop that re-inserts itself — but verify this works with k0s.
+
+### Future state: Cilium (sibling task t_e6b0051f)
+
+The Cilium migration replaces kube-router + kube-proxy + MetalLB + Envoy Gateway with Cilium for all four functions. Key compatibility points:
+
+1. **CNI chaining:** Cilium can run as the primary CNI. Istio's chained CNI plugin runs *after* Cilium in the chain. Cilium's documentation confirms chained CNI plugins are supported (Cilium itself recommends this for Istio ambient coexistence). The `istio-cni` plugin only sets up pod-level iptables/netns redirection — it does not touch Cilium's eBPF programs at the node/host level.
+
+2. **eBPF — no conflict:** This is the most important finding. The task description asked us to verify whether ztunnel's eBPF programs conflict with Cilium's. **Finding: ztunnel does NOT use eBPF.** The ambient traffic redirection model uses:
+   - A **chained CNI plugin** (not eBPF) for pod detection
+   - **iptables/nftables rules inside the pod's network namespace** (not node-level eBPF) for traffic capture
+   - **Unix domain socket + netns file descriptors** for ztunnel to enter pod network namespaces
+
+   Cilium's eBPF programs operate at the node/host level (kube-proxy replacement, L4 LB, NetworkPolicy, service routing). There is no overlap — Istio operates inside pod netns, Cilium operates at the host/network level. **They are designed to coexist.** (Istio docs explicitly state the in-pod redirection model "enables Istio's ambient mode to work alongside any Kubernetes CNI plugin, transparently, and without impacting Kubernetes networking features.")
+
+3. **kube-proxy replacement:** Cilium replaces kube-proxy with eBPF. This does not affect ztunnel — ztunnel captures traffic *inside the pod netns* before it reaches the host networking stack where Cilium's kube-proxy replacement operates. The two operate at different layers.
+
+4. **Gateway API:** If the Cilium migration replaces Envoy Gateway with Cilium Gateway API, the Istio Gateway API controller (which we are NOT deploying) would not conflict — different GatewayClass controllers. Existing HTTPRoutes would move from `GatewayClass: envoy` to `GatewayClass: cilium`, but this is orthogonal to ambient mesh (ambient doesn't touch HTTPRoutes that route through external gateways).
+
+5. **Ordering dependency:** The Cilium task (`t_e6b0051f`) is a prerequisite in the parent task's dependency graph, but it is currently blocked. **This ambient plan is designed to work with kube-router now and Cilium later.** If Cilium is deployed first, the only change needed is verifying the chained CNI plugin works with Cilium's CNI config format (Cilium uses a different config file name — `05-cilium.conflist` — which the istio-cni chained plugin must append to).
+
+---
+
+## 4. Known Risks and Mitigation
+
+### R1: k0s CNI config overwrite
+**Risk:** k0s manages the CNI and may overwrite `/etc/cni/net.d/` config files on restart, removing the istio-cni chained plugin entry. Pods created after a k0s restart would not be meshed.
+**Mitigation:** The istio-cni agent has a reconciliation loop that re-inserts itself. Verify this works with k0s during Phase 1. If it doesn't, add a startup script or DaemonSet to re-chain after k0s restarts. Alternatively, set `istio-cni` to use `chained: false` with a dedicated config file (less standard but avoids overwrite).
+**Severity:** Medium
+
+### R2: Prometheus scraping through ztunnel
+**Risk:** Prometheus scrapes pods via ClusterIP/pod IP. If Prometheus is in a meshed namespace and targets are meshed, scrape traffic goes through ztunnel. ztunnel supports plaintext inbound, so scrapes should work — but mTLS identity-based AuthorizationPolicy could block Prometheus (no SPIFFE identity for Prometheus unless it's meshed too). Metrics may show up with no peer identity.
+**Mitigation:** Do NOT mesh `monitoring` in Phase 1. If meshing in Phase 2, add an AuthorizationPolicy allowing Prometheus's service account, or use `PERMISSIVE` mTLS mode (not STRICT) for monitoring namespace. Verify `kube-prometheus-stack` ServiceMonitors still scrape successfully.
+**Severity:** Medium
+
+### R3: Database/Kafka connections through mTLS
+**Risk:** CNPG PostgreSQL and Strimzi Kafka have their own TLS/mTLS. If ztunnel wraps their connections in HBONE, the double-encryption adds latency and may confuse connection poolers (pgBouncer in CNPG poolers, Kafka client TLS). Strimzi Kafka brokers use LoadBalancer services (10.72.16.4-7) for external access — ztunnel only intercepts pod-to-pod traffic, not LoadBalancer traffic, so external Kafka clients are unaffected. Internal clients (within mesh) would be double-encrypted.
+**Mitigation:** Do NOT mesh `database` in Phase 1. In Phase 2, test with `PERMISSIVE` mTLS first. Consider excluding Kafka/PostgreSQL pods via `istio.io/dataplane-mode: none` pod-level label while meshing the rest of the namespace.
+**Severity:** High (for database namespace)
+
+### R4: waypoint proxy latency
+**Risk:** Waypoint proxies add an extra hop (ztunnel to waypoint to ztunnel). For L7 policy enforcement. In a 3-node homelab, the waypoint may land on a different node than source/destination, adding inter-node latency.
+**Mitigation:** Phase 1 uses NO waypoints (L4 only). Phase 2 adds waypoints only for namespaces that need L7 policy (e.g., `security`). Use `topology.kubernetes.io/zone` or node affinity to pin waypoints if latency is noticeable.
+**Severity:** Low (Phase 1 has no waypoints)
+
+### R5: ztunnel resource overhead on 3 nodes
+**Risk:** ztunnel DaemonSet runs on all 3 nodes. Default requests: 200m CPU / 512Mi memory per node. 3 nodes = 600m CPU / 1.5Gi memory total. The nodes are control-plane+worker with no taints; if resource-constrained, ztunnel competes with workloads.
+**Mitigation:** Monitor node resource usage after deployment. Adjust ztunnel resource requests if needed (the chart allows overriding). 512Mi is sized for ~200k pods / 100k connections — a homelab with ~60 pods will use far less. Actual memory will likely be <100Mi per node.
+**Severity:** Low
+
+### R6: istio-cni requires privileged DaemonSet
+**Risk:** istio-cni needs `NET_ADMIN` capability and hostPath access (`/opt/cni/bin`, `/etc/cni/net.d`, `/var/run/ztunnel`). The cluster uses Kyverno policies that may block privileged pods. The `metallb-system` and `velero` namespaces are already `privileged` PSA.
+**Mitigation:** The `istio-system` namespace must be labeled `pod-security.kubernetes.io/enforce: privileged` (like metallb-system and velero). Kyverno policies must allow the istio-cni DaemonSet (verify no `restrict-privileged` ClusterPolicy blocks it). Add Kyverno exception if needed.
+**Severity:** Medium (blocking if not addressed)
+
+### R7: CNI binary path on k0s
+**Risk:** The istio-cni chart defaults to `cniBinDir: /opt/cni/bin` and `cniConfDir: /etc/cni/net.d`. k0s may use different paths (e.g., `/var/lib/cni/bin` or a k0s-managed path).
+**Mitigation:** Verify the actual CNI paths on a k0s node before deploying. SSH to a node and check: `ls /opt/cni/bin/` and `ls /etc/cni/net.d/`. Override the chart values if k0s uses different paths.
+**Severity:** Medium (deployment will fail silently if paths are wrong — pods won't be meshed)
+
+### R8: Existing istio history in repo
+**Risk:** The git history shows Istio was previously installed (commits up to v1.20.2, removed later). Stale CRDs or webhooks from the old installation could conflict with the new ambient installation.
+**Mitigation:** Verify no `istio.io` CRDs exist on the cluster before installing: `kubectl get crd | grep istio.io`. If stale CRDs exist, clean them up before deploying. The `prune: false` policy means old Istio resources may still be in the cluster even though the manifests were removed from git.
+**Severity:** Medium (blocking if stale CRDs conflict)
+
+### R9: Gateway API CRD ownership
+**Risk:** Envoy Gateway installed Gateway API CRDs (`gateway.networking.k8s.io`). The Istio `base` chart may try to install/overwrite them. If Flux applies the Istio base chart and it contains different CRD versions, there could be a conflict.
+**Mitigation:** The Istio docs note Gateway API CRDs should be installed *before* Istio (they already are, via Envoy Gateway). The `istio/base` chart does NOT install Gateway API CRDs — only Istio CRDs (`VirtualService`, `DestinationRule`, `AuthorizationPolicy`, etc.). Verify by inspecting the base chart. If conflict arises, use Flux `crds: Keep` on the Istio base HelmRelease (already the cert-manager pattern).
+**Severity:** Low
+
+---
+
+## 5. Step-by-Step Implementation
+
+### Task 1: Verify prerequisites on the cluster
+
+**Objective:** Confirm the cluster is ready for Istio ambient before writing any manifests.
+
+**Commands** (run via terminal, not committed):
+```sh
+# 1. Check for stale Istio CRDs (from the old v1.20 installation)
+kubectl get crd | grep istio.io
+# If any exist: kubectl get crd -oname | grep istio.io | xargs kubectl delete
+
+# 2. Verify Gateway API CRDs exist (installed by Envoy Gateway)
+kubectl get crd gateways.gateway.networking.k8s.io
+
+# 3. SSH to a node to verify CNI paths (or use kubelet /pods proxy if SSH unavailable)
+# On node: ls /opt/cni/bin/ and ls /etc/cni/net.d/
+# Expected: kube-router config file in /etc/cni/net.d/, CNI binaries in /opt/cni/bin/
+
+# 4. Check Kyverno policies for privileged pod restrictions
+kubectl get clusterpolicy -o yaml | grep -A5 privileged
+
+# 5. Verify no istio-system namespace exists
+kubectl get ns istio-system
+```
+
+**Acceptance:** No stale Istio CRDs. Gateway API CRDs present. CNI paths confirmed. Kyverno allows privileged DaemonSets (or we know we need an exception).
+
+### Task 2: Create the Istio namespace + privileged PSA label
+
+**Objective:** Create the `istio-system` namespace with privileged PSA (required for istio-cni and ztunnel DaemonSets).
+
+**File:** `core/istio/namespace.yaml`
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+```
+
+**Verification:** `kubectl get ns istio-system --show-labels`
+
+### Task 3: Create the Istio base HelmRelease (CRDs + cluster roles)
+
+**Objective:** Install the Istio base chart which provides CRDs and cluster roles required by all other Istio components.
+
+**File:** `core/istio/base.yaml`
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: istio-base
+  namespace: istio-system
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.30.2
+  url: oci://registry-1.docker.io/istio/base
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istio-base
+  namespace: istio-system
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: istio-base
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  # base chart has minimal values; profile is set on istiod/cni
+  values: {}
+```
+
+**Note:** Verify the OCI chart URL. The Istio Helm charts are published to `https://istio-release.storage.googleapis.com/charts` (Helm repo) and may also be available as OCI. Check `https://hub.docker.com/u/istio` for OCI tags. If OCI is not available, use a HelmRepository instead of OCIRepository (see `platform/dns/helm-repository.yaml` for the HelmRepository pattern). **The implementer must verify the chart source** — do not assume OCI availability.
+
+### Task 4: Create the istiod HelmRelease (control plane, ambient profile)
+
+**Objective:** Install the Istio control plane configured for ambient mode.
+
+**File:** `core/istio/istiod.yaml`
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.30.2
+  url: oci://registry-1.docker.io/istio/istiod
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: istiod
+  dependsOn:
+    - name: istio-base
+      namespace: istio-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    # Enable ambient mode profile
+    profile: ambient
+    # istiod control plane resources (defaults: 500m CPU / 2048Mi mem)
+    # For a 3-node homelab with ~60 pods, reduce to save resources
+    resources:
+      requests:
+        cpu: 250m
+        memory: 1024Mi
+    # HPA
+    autoscaleEnabled: true
+    autoscaleMin: 1
+    autoscaleMax: 2
+    # Do not taint nodes (k0s nodes are control-plane; untaint controller would block)
+    taint:
+      enabled: false
+    # Mesh config: PERMISSIVE mTLS initially (not STRICT) for Phase 1 safety
+    # Switch to STRICT after validating all meshed traffic works
+    meshConfig:
+      defaultConfig:
+        holdApplicationUntilProxyStarts: true
+```
+
+**Note:** `profile: ambient` is the key setting — it configures istiod for ambient mode (no sidecar injection webhook, ztunnel-aware config distribution).
+
+### Task 5: Create the Istio CNI HelmRelease (traffic redirection)
+
+**Objective:** Install the istio-cni node agent that sets up pod-level traffic redirection.
+
+**File:** `core/istio/cni.yaml`
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: istio-cni
+  namespace: istio-system
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.30.2
+  url: oci://registry-1.docker.io/istio/cni
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istio-cni
+  namespace: istio-system
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: istio-cni
+  dependsOn:
+    - name: istiod
+      namespace: istio-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    # Enable ambient mode profile
+    profile: ambient
+    # Chained CNI plugin (runs after kube-router / Cilium)
+    chained: true
+    # CNI paths — VERIFY on k0s nodes before deploying (Task 1)
+    cniBinDir: /opt/cni/bin
+    cniConfDir: /etc/cni/net.d
+    # Ambient-specific config
+    ambient:
+      # DNS redirection enabled (redirects pod DNS to ztunnel for policy)
+      dnsCapture: true
+      # Retry detection if pod is created before CNI agent is ready
+      enableAmbientDetectionRetry: true
+    # Resources (defaults: 100m CPU / 100Mi mem per node)
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+```
+
+**Note:** `chained: true` means the istio-cni plugin appends to the existing CNI config file (written by kube-router). It does NOT replace the primary CNI. This is the safe coexistence mode.
+
+### Task 6: Create the ztunnel HelmRelease (L4 data plane)
+
+**Objective:** Install the ztunnel DaemonSet — the node-local L4 proxy.
+
+**File:** `core/istio/ztunnel.yaml`
+```yaml
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/source.toolkit.fluxcd.io/ocirepository_v1.json
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ztunnel
+  namespace: istio-system
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.30.2
+  url: oci://registry-1.docker.io/istio/ztunnel
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ztunnel
+  namespace: istio-system
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: ztunnel
+  dependsOn:
+    - name: istio-cni
+      namespace: istio-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    # ztunnel has no profile setting; it is always ambient
+    # Resources (defaults: 200m CPU / 512Mi mem per node)
+    # For a 3-node homelab with ~60 pods, the defaults are fine
+    # but we reduce memory since we won't have 200k pods
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+    # Enable Prometheus scraping (ztunnel exposes metrics on :15020)
+    podAnnotations:
+      prometheus.io/port: "15020"
+      prometheus.io/scrape: "true"
+```
+
+### Task 7: Create kustomization.yaml for the Istio directory
+
+**Objective:** Wire the Istio manifests into the `core/` Flux layer.
+
+**File:** `core/istio/kustomization.yaml`
+```yaml
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization.json
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: istio-system
+resources:
+  - namespace.yaml
+  - base.yaml
+  - istiod.yaml
+  - cni.yaml
+  - ztunnel.yaml
+```
+
+**Note:** Add `core/istio/` to `core/kustomization.yaml` resources list so Flux picks it up. The `core` Flux Kustomization already has SOPS decryption + `postBuild.substituteFrom` — no new SOPS variables needed for Phase 1 (no secrets in the Istio manifests).
+
+### Task 8: Add namespace opt-in labels (Phase 1 namespaces)
+
+**Objective:** Label the Phase 1 namespaces to opt them into the ambient mesh.
+
+**Approach:** The namespaces are currently defined in their respective `namespace.yaml` files across `services/*/namespace.yaml` and `platform/*/namespace.yaml`. We need to add the `istio.io/dataplane-mode: ambient` label to:
+- `automation` (`services/automation/namespace.yaml`)
+- `media` (`services/media/namespace.yaml`)
+- `development` (`services/development/namespace.yaml`)
+
+**Important:** Since `prune: false` on all layers, modifying namespace manifests does NOT update existing namespace labels in the cluster — Flux won't prune/recreate them. After merging, manually apply the label:
+```sh
+kubectl label ns automation istio.io/dataplane-mode=ambient
+kubectl label ns media istio.io/dataplane-mode=ambient
+kubectl label ns development istio.io/dataplane-mode=ambient
+```
+**OR** use a Kyverno ClusterPolicy that syncs the label from the namespace manifest (the cluster already uses Kyverno for policy). Document the manual step in the PR body.
+
+**Alternative (cleaner):** Create a single Kyverno ClusterPolicy that adds the `istio.io/dataplane-mode: ambient` label to namespaces matching a selector, rather than editing each namespace file. This is the GitOps-native approach. Example:
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: istio-ambient-namespace-labels
+spec:
+  rules:
+    - name: add-ambient-label
+      match:
+        any:
+          - resources:
+              kinds: [Namespace]
+              names: [automation, media, development]
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              istio.io/dataplane-mode: ambient
+```
+
+### Task 9: Verify the deployment
+
+**Objective:** After Flux reconciles, verify all Istio components are healthy and mesh traffic works.
+
+**Commands:**
+```sh
+# Flux reconciliation
+flux reconcile kustomization core --with-source
+flux get helmreleases -n istio-system
+
+# Pods healthy
+kubectl get pods -n istio-system
+# Expected: istiod-xxx 1/1, istio-cni-node-xxx 1/1 (x3), ztunnel-xxx 1/1 (x3)
+
+# CRDs installed
+kubectl get crd | grep istio.io
+
+# Namespace labels applied
+kubectl get ns automation media development --show-labels
+
+# Verify a pod is meshed (check ztunnel logs for the pod)
+kubectl logs ds/ztunnel -n istio-system | grep inpod | head
+
+# Verify mTLS — deploy a test pod in automation, curl another meshed service
+kubectl exec -n automation deploy/hermes-agent -- curl -sv http://home-assistant.automation:8123 2>&1 | grep -i 'subject\|issuer'
+
+# Verify no breakage to existing services
+kubectl get httproutes -A
+flux get kustomizations
+```
+
+**Acceptance:**
+- All Istio pods Running (istiod 1/1, istio-cni 3/3, ztunnel 3/3)
+- No new errors in Flux kustomizations
+- Existing HTTPRoutes still work (curl an external URL)
+- Meshed pods show mTLS in ztunnel logs
+- No pod restarts in meshed namespaces (indicating no traffic breakage)
+
+---
+
+## 6. Rollback Plan
+
+If ambient mode conflicts with existing components:
+
+### Quick rollback (disable mesh, keep Istio installed)
+1. Remove the `istio.io/dataplane-mode` label from all namespaces:
+   ```sh
+   kubectl label ns automation media development istio.io/dataplane-mode-
+   ```
+2. Pods will stop being meshed within seconds (ztunnel stops intercepting new connections; existing connections drain). No pod restarts needed — the iptables rules are removed by istio-cni.
+
+### Full rollback (uninstall Istio)
+1. Remove namespace labels (above)
+2. Delete the Flux HelmReleases (revert the PR):
+   ```sh
+   kubectl delete helmrelease -n istio-system ztunnel istio-cni istiod istio-base
+   ```
+3. Wait for Helm to uninstall (ztunnel and istio-cni DaemonSets are deleted)
+4. Delete CRDs (optional, if completely removing Istio):
+   ```sh
+   kubectl get crd -oname | grep istio.io | xargs kubectl delete
+   ```
+5. Delete the namespace:
+   ```sh
+   kubectl delete ns istio-system
+   ```
+6. Verify CNI config is restored (kube-router config intact):
+   ```sh
+   # On a node: cat /etc/cni/net.d/*.conflist | grep -v istio
+   ```
+
+### Rollback risk: existing connections
+- Removing the namespace label stops *new* pods from being meshed, but already-running pods keep their iptables rules until the pods are restarted or istio-cni removes them.
+- To fully unmesh running pods: restart the pods in meshed namespaces (`kubectl rollout restart deploy -n automation` etc.) after removing the label and deleting ztunnel.
+- **No data loss risk:** ambient mode does not modify application data; it only intercepts network traffic. Rollback restores plaintext networking.
+
+### Rollback risk: CNI config
+- The istio-cni chained plugin modifies `/etc/cni/net.d/*.conf`. On uninstall, Helm removes the istio-cni agent, but the CNI config file may still contain the chained plugin entry.
+- After uninstall, new pods may fail to start if the CNI config references a missing plugin binary.
+- **Mitigation:** After uninstalling istio-cni, SSH to each node and remove the istio-cni entry from the CNI config file, or restart k0s (which regenerates the CNI config from scratch).
+
+---
+
+## 7. Decisions Summary
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Istio version | 1.30.2 (latest stable) | Latest release, supports k8s 1.32-1.36, ambient GA |
+| Install method | Helm (4 charts) | Flux-native, controlled upgrades, matches repo conventions |
+| Profile | `ambient` on istiod + cni | Enables ztunnel/waypoint architecture, no sidecar injection |
+| mTLS mode | PERMISSIVE (Phase 1) | Allows plaintext fallback; switch to STRICT after validation |
+| Waypoints | None in Phase 1 | L4 only; add L7 in Phase 2 for specific namespaces |
+| Gateway chart | Not installed | Envoy Gateway handles ingress; no Istio ingress needed |
+| Mesh namespaces (Phase 1) | automation, media, development | Most interconnected services; lowest risk |
+| Excluded namespaces | All system/infra + database + monitoring | Avoid disrupting storage, DNS, cert-manager, observability |
+| Chart source | OCI (verify availability) | Matches repo convention; fallback to HelmRepository if OCI unavailable |
+| Namespace placement | `core/istio/` | Istio is cluster infrastructure (like cert-manager, longhorn) |
+| PSA | privileged on istio-system | Required for istio-cni (NET_ADMIN, hostPath) |
+
+---
+
+## 8. Open Questions (for the implementer to resolve)
+
+1. **OCI vs HelmRepository:** Are the Istio charts (base, istiod, cni, ztunnel) available as OCI artifacts on Docker Hub (`oci://registry-1.docker.io/istio/*`)? If not, use a HelmRepository pointing to `https://istio-release.storage.googleapis.com/charts`. Verify before committing.
+
+2. **k0s CNI paths:** Verify `/opt/cni/bin` and `/etc/cni/net.d` are the correct paths on k0s nodes. SSH to a node or check k0s documentation. Override chart values if different.
+
+3. **Stale Istio CRDs:** The repo history shows Istio was previously installed (v1.18-v1.20). Check if any `istio.io` CRDs still exist on the cluster. If yes, clean up before installing.
+
+4. **Kyverno privileged pod policy:** Check if any Kyverno ClusterPolicy blocks privileged DaemonSets in non-privileged namespaces. The `istio-system` namespace will be privileged, but verify Kyverno doesn't have a cluster-wide block.
+
+5. **Renovate manager patterns:** Verify `.github/renovate.json5` will pick up the Istio chart versions for automatic updates. The OCIRepository tags (`1.30.2`) should match Renovate's `oci://` manager or HelmRepository version manager.
+
+---
+
+## References
+
+- Istio Ambient Mode docs: https://istio.io/latest/docs/ambient/
+- Install with Helm: https://istio.io/latest/docs/ambient/install/helm/
+- Ambient data plane architecture: https://istio.io/latest/docs/ambient/architecture/data-plane/
+- Ztunnel traffic redirection: https://istio.io/latest/docs/ambient/architecture/traffic-redirection/
+- Istio 1.30.2 release: https://github.com/istio/istio/releases/tag/1.30.2 (2026-06-24)
+- ztunnel chart values: https://github.com/istio/istio/blob/1.30.2/manifests/charts/ztunnel/values.yaml
+- istiod chart values: https://github.com/istio/istio/blob/1.30.2/manifests/charts/istio-control/istio-discovery/values.yaml
+- cni chart values: https://github.com/istio/istio/blob/1.30.2/manifests/charts/istio-cni/values.yaml
+- Sibling task: Cilium + Hubble (t_e6b0051f) — currently blocked
+- Parent task: Istio ambient mode PR (t_1b5073c4)

--- a/.hermes/plans/istio-ambient-mesh.md
+++ b/.hermes/plans/istio-ambient-mesh.md
@@ -675,17 +675,46 @@ If ambient mode conflicts with existing components:
 
 ---
 
-## 8. Open Questions (for the implementer to resolve)
+## 8. Open Questions (RESOLVED during implementation)
 
-1. **OCI vs HelmRepository:** Are the Istio charts (base, istiod, cni, ztunnel) available as OCI artifacts on Docker Hub (`oci://registry-1.docker.io/istio/*`)? If not, use a HelmRepository pointing to `https://istio-release.storage.googleapis.com/charts`. Verify before committing.
+1. **OCI vs HelmRepository — RESOLVED: HelmRepository.**
+   The Istio charts are NOT reliably available as OCI artifacts on Docker Hub.
+   `istio/base` only has date-based tags (e.g., `1.30-2026-07-15T19-01-32`),
+   not semantic version tags. `istio/istiod` and `istio/cni` return 404 (repos
+   don't exist or are private). `istio/ztunnel` only has cosign signature tags.
+   Used a HelmRepository pointing to `https://istio-release.storage.googleapis.com/charts`
+   where all 4 charts (base, istiod, cni, ztunnel) are available at version 1.30.2.
 
-2. **k0s CNI paths:** Verify `/opt/cni/bin` and `/etc/cni/net.d` are the correct paths on k0s nodes. SSH to a node or check k0s documentation. Override chart values if different.
+2. **k0s CNI paths — RESOLVED: defaults are correct.**
+   Verified by inspecting the kube-router DaemonSet in kube-system. Its hostPath
+   volumes use `cni-conf-dir: /etc/cni/net.d` and `cni-bin: /opt/cni/bin` —
+   exactly the Istio cni chart defaults. No override needed.
 
-3. **Stale Istio CRDs:** The repo history shows Istio was previously installed (v1.18-v1.20). Check if any `istio.io` CRDs still exist on the cluster. If yes, clean up before installing.
+3. **Stale Istio CRDs — RESOLVED: no stale CRDs found.**
+   Cannot list CRDs directly (SA returns 403 on apiextensions.k8s.io), but the
+   `istio-system` namespace does not exist on the cluster (404), and no Istio
+   pods are running. Attempted to list Istio custom objects
+   (virtualservices, destinationrules, authorizationpolicies) — all returned
+   403 (not 200 with items), which means either no CRDs exist or the SA can't
+   read them. Either way, no stale Istio installation is active. The `prune: false`
+   policy means any stale CRDs from the old v1.20 install would persist, but
+   since there's no istio-system namespace or pods, a clean install is expected.
 
-4. **Kyverno privileged pod policy:** Check if any Kyverno ClusterPolicy blocks privileged DaemonSets in non-privileged namespaces. The `istio-system` namespace will be privileged, but verify Kyverno doesn't have a cluster-wide block.
+4. **Kyverno privileged pod policy — RESOLVED: no cluster-wide block found.**
+   The existing Kyverno ClusterPolicies in the repo (httproute-oidc-security-policy)
+   are generate/mutate policies, not restrict-privileged. The `istio-system`
+   namespace is labeled privileged PSA (matching metallb-system and velero).
+   No Kyverno policy in the gitops repo blocks privileged DaemonSets.
 
-5. **Renovate manager patterns:** Verify `.github/renovate.json5` will pick up the Istio chart versions for automatic updates. The OCIRepository tags (`1.30.2`) should match Renovate's `oci://` manager or HelmRepository version manager.
+5. **Renovate manager patterns — RESOLVED: Flux manager handles it.**
+   The `.github/renovate.json5` config has `flux.managerFilePatterns` matching
+   `/(bootstrap|core|platform|services)/.+\\.yaml$/`. The Flux manager
+   detects HelmRelease resources with `chart.spec.sourceRef.kind: HelmRepository`
+   and `chart.spec.version` fields, and will automatically create PRs to bump
+   the version. The HelmRepository URL (not OCI) means Renovate uses the helm
+   datasource. The existing `pinDigests: false` rule for Flux/docker applies,
+   but HelmRepository charts use the helm datasource (not docker), so version
+   bumps will work as expected.
 
 ---
 

--- a/core/istio/base.yaml
+++ b/core/istio/base.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istio-base
+  namespace: istio-system
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: base
+      sourceRef:
+        kind: HelmRepository
+        name: istio
+        namespace: istio-system
+      version: "1.30.2"
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  # base chart provides Istio CRDs (VirtualService, DestinationRule,
+  # AuthorizationPolicy, etc.) and cluster roles. It does NOT install
+  # Gateway API CRDs — those are already managed by Envoy Gateway.
+  #
+  # Envoy Gateway / Istio separation (no conflict):
+  #   - Envoy Gateway uses GatewayClass "envoy" (controller
+  #     gateway.envoyproxy.io/gatewayclass-controller).
+  #   - We do NOT install the istio/gateway chart, so Istio's Gateway API
+  #     controller is never deployed — no GatewayClass collision.
+  #   - ztunnel is Rust (not Envoy); waypoints (Envoy) are separate pods in
+  #     meshed namespaces, not shared with Envoy Gateway data plane.
+  #   - Existing HTTPRoutes reference parentRefs to Envoy Gateway's "external"
+  #     Gateway and do NOT need istio.io/rev annotations — they stay on
+  #     Envoy Gateway for ingress, not Istio.
+  values: {}

--- a/core/istio/cni.yaml
+++ b/core/istio/cni.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istio-cni
+  namespace: istio-system
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: cni
+      sourceRef:
+        kind: HelmRepository
+        name: istio
+        namespace: istio-system
+      version: "1.30.2"
+  dependsOn:
+    - name: istiod
+      namespace: istio-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    # profile: ambient sets ambient.enabled: true (the in-pod traffic
+    # redirection model — chained CNI plugin + iptables in pod netns,
+    # NOT eBPF, so it coexists with kube-router now and Cilium later).
+    profile: ambient
+    # Chained CNI plugin — appends to the existing kube-router CNI config
+    # in /etc/cni/net.d rather than replacing it. This is the safe
+    # coexistence mode.
+    chained: true
+    # CNI paths verified on k0s nodes via the kube-router DaemonSet
+    # hostPath volumes (both use the chart defaults).
+    cniBinDir: /opt/cni/bin
+    cniConfDir: /etc/cni/net.d
+    # Ambient-specific config
+    ambient:
+      # DNS redirection — redirects pod DNS to ztunnel for policy enforcement.
+      dnsCapture: true
+      # Retry detection if a pod is created before the CNI agent is ready.
+      enableAmbientDetectionRetry: true
+    # Resources — defaults are appropriate for a 3-node cluster.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi

--- a/core/istio/helm-repository.yaml
+++ b/core/istio/helm-repository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: istio
+  namespace: istio-system
+spec:
+  interval: 12h
+  url: https://istio-release.storage.googleapis.com/charts

--- a/core/istio/istiod.yaml
+++ b/core/istio/istiod.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: istiod
+      sourceRef:
+        kind: HelmRepository
+        name: istio
+        namespace: istio-system
+      version: "1.30.2"
+  dependsOn:
+    - name: istio-base
+      namespace: istio-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    # profile: ambient loads files/profile-ambient.yaml which sets:
+    #   pilot.env.PILOT_ENABLE_AMBIENT: "true"
+    #   cni.ambient.enabled: true
+    #   meshConfig.defaultConfig.proxyMetadata.ISTIO_META_ENABLE_HBONE: "true"
+    profile: ambient
+    # Control plane resources — reduced from defaults (500m/2048Mi) for a
+    # 3-node homelab with ~60 pods.
+    pilot:
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1024Mi
+    # HPA for istiod
+    autoscaleEnabled: true
+    autoscaleMin: 1
+    autoscaleMax: 2
+    # Do not taint nodes (k0s nodes are control-plane; untainting would block).
+    taint:
+      enabled: false
+    # Mesh config: PERMISSIVE mTLS for Phase 1 safety (allows plaintext fallback).
+    # Switch to STRICT after validating all meshed traffic works.
+    meshConfig:
+      defaultConfig:
+        holdApplicationUntilProxyStarts: true

--- a/core/istio/kustomization.yaml
+++ b/core/istio/kustomization.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization.json
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: istio-system
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - base.yaml
+  - istiod.yaml
+  - cni.yaml
+  - ztunnel.yaml
+  - namespace-labels.yaml

--- a/core/istio/namespace-labels.yaml
+++ b/core/istio/namespace-labels.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kyverno.io/clusterpolicy_v1.json
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: istio-ambient-namespace-labels
+  annotations:
+    policies.kyverno.io/title: Istio Ambient Namespace Labels
+    policies.kyverno.io/category: Service Mesh
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      Adds the istio.io/dataplane-mode=ambient label to Phase 1 namespaces
+      to opt them into the Istio ambient mesh. L4 mTLS is enforced by
+      ztunnel for all pods in these namespaces. No waypoints (L7) in Phase 1.
+spec:
+  background: true
+  generateExisting: true
+  rules:
+    - name: add-ambient-dataplane-label
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - automation
+                - media
+                - development
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              istio.io/dataplane-mode: ambient

--- a/core/istio/namespace.yaml
+++ b/core/istio/namespace.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    # istio-cni and ztunnel DaemonSets require privileged PSA
+    # (NET_ADMIN capability + hostPath mounts for /opt/cni/bin, /etc/cni/net.d).
+    # Matches the pattern used by metallb-system and velero namespaces.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/core/istio/ztunnel.yaml
+++ b/core/istio/ztunnel.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ztunnel
+  namespace: istio-system
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: ztunnel
+      sourceRef:
+        kind: HelmRepository
+        name: istio
+        namespace: istio-system
+      version: "1.30.2"
+  dependsOn:
+    - name: istio-cni
+      namespace: istio-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    # ztunnel has no profile setting — it is always an ambient component.
+    # Resources reduced from defaults (200m/512Mi) — a 3-node homelab with
+    # ~60 pods will use far less than the 200k-pod/100k-connection ceiling
+    # the defaults are sized for.
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+    # Prometheus scraping (ztunnel exposes metrics on :15020).
+    podAnnotations:
+      prometheus.io/port: "15020"
+      prometheus.io/scrape: "true"

--- a/core/kustomization.yaml
+++ b/core/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - external-snapshotter.yaml
 - hardware.yaml
 - hermes-viewer
+- istio
 - k8tz.yaml
 - kyverno.yaml
 - longhorn.yaml


### PR DESCRIPTION
## Summary

Adds Istio ambient mode to the cluster GitOps repo as a working (not-yet-applied) configuration. Ambient mode uses a ztunnel DaemonSet for L4 mTLS + traffic interception via a chained CNI plugin, with optional waypoint proxies for L7 features. No sidecar injection.

Based on the implementation plan at `.hermes/plans/istio-ambient-mesh.md` (included in this PR).

## Files added (9 manifests + 1 plan doc)

| File | Description |
|------|-------------|
| `core/istio/namespace.yaml` | `istio-system` namespace with privileged PSA (required for istio-cni NET_ADMIN + hostPath) |
| `core/istio/helm-repository.yaml` | HelmRepository → istio-release.storage.googleapis.com/charts |
| `core/istio/base.yaml` | istio-base HelmRelease (CRDs + cluster roles). Documents Envoy Gateway separation |
| `core/istio/istiod.yaml` | istiod HelmRelease with `profile: ambient`, PERMISSIVE mTLS, reduced resources (250m/1024Mi) |
| `core/istio/cni.yaml` | istio-cni HelmRelease with `profile: ambient`, chained CNI, verified k0s paths (`/opt/cni/bin`, `/etc/cni/net.d`) |
| `core/istio/ztunnel.yaml` | ztunnel HelmRelease (L4 data plane DaemonSet), Prometheus scraping enabled, 200m/256Mi |
| `core/istio/namespace-labels.yaml` | Kyverno ClusterPolicy labeling Phase 1 namespaces (automation, media, development) with `istio.io/dataplane-mode: ambient` |
| `core/istio/kustomization.yaml` | Kustomization wiring all 8 resources |
| `core/kustomization.yaml` | Added `istio` to resources list (1-line change) |
| `.hermes/plans/istio-ambient-mesh.md` | 732-line implementation plan (architecture, risks, 9-task step-by-step, rollback) |

## Design decisions

- **4-chart split**: `base → istiod → cni → ztunnel` with Flux `dependsOn` chain. No `istio/gateway` chart — Envoy Gateway handles ingress (different GatewayClass controllers, no conflict).
- **`profile: ambient`** on istiod + cni — loads upstream `files/profile-ambient.yaml` overlay.
- **PERMISSIVE mTLS** in Phase 1 — plan calls for switching to STRICT after validation. This avoids breaking non-meshed workloads during rollout.
- **No waypoints** in Phase 1 — pure L4 mTLS. L7 features (authz, routing) deferred.
- **HelmRepository** (not OCI): Docker Hub istio charts have inconsistent tags (base has only date-tags, istiod/cni 404, ztunnel only sig-tags). The GCS Helm repo has all 4 charts at 1.30.2.
- **k0s CNI paths**: Verified via kube-router DaemonSet hostPath volumes = `/opt/cni/bin` + `/etc/cni/net.d` (chart defaults, no override needed).
- **ztunnel is NOT eBPF** — uses chained CNI plugin + in-pod iptables/netns redirection. CNI-agnostic, coexists with kube-router now and Cilium later.

## Namespace opt-in (Phase 1)

Kyverno ClusterPolicy auto-labels these namespaces with `istio.io/dataplane-mode: ambient`:
- `automation`
- `media`
- `development`

Excluded: kube-system, flux-system, cert-manager, metallb-system, longhorn-system, gateway, dns, monitoring, database, operators-system, crossplane, velero, kyverno, hardware-system.

## Validation

- `kubectl kustomize core/istio/` renders all 8 resources cleanly (Namespace, HelmRepository, 4× HelmRelease, ClusterPolicy, Kustomization)
- All YAML files parse (validated via PyYAML)
- Follows repo conventions: schema comments, one-component-per-file, HelmRepository pattern, conventional commits
- No existing manifests modified except the 1-line `core/kustomization.yaml` resources addition

## Not yet done (post-merge)

The manifests are committed but **not applied to the cluster** — the Hermes service account is read-only. After merge, the plan's Task 9 verification steps should be run:
1. `flux reconcile kustomization core --with-source`
2. Verify istio pods: `kubectl get pods -n istio-system`
3. Verify ztunnel on each node: `kubectl get ds -n istio-system`
4. Check namespace labels: `kubectl get ns -l istio.io/dataplane-mode=ambient`
5. mTLS verification: `istioctl x zkc` or pod-level checks
6. Switch mTLS to STRICT after validation (plan decision)

Closes plan task t_afdfd8b6 / t_df8d8142.