### PR TITLE
feat(automation): add neolink RTSP bridge for Reolink E1

### DIFF
--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -123,10 +123,13 @@ stringData:
     HERMES_OBSIDIAN_AUTH_TOKEN: ENC[AES256_GCM,data:PqnnUhme06Eq8nnJ32AK5c8+pCsP0ebFp2Bk2NsZ65Y=,iv:5hp2ZWRU6Lig0H3w0S9pwyaCCqt0kYWCe+Wzi15QvJI=,tag:e92ySyrqkpsNV5RX9tcUMg==,type:str]
     HERMES_OBSIDIAN_VAULT_NAME: ENC[AES256_GCM,data:FFSrxQ==,iv:4Zm0Fm0k7xC+UcKgWSAENVuC/bJukbLvK+j6VRFnK2Y=,tag:b/n+bV26YlUt45i5woykgA==,type:str]
     MATTERMOST_DB_PASSWORD: ENC[AES256_GCM,data:+VbJuW0bNIRr3DslsNBdbuQ4c2gv09rsCSoB1tZdE+RMM6pIIwPoVq9bgkv6flBWlMpo0GTxZvJQo9lnTTH0Ag==,iv:l+llcw17LYJeWDnQespP2JpGcJ2qHaHBeTB0ZFBDI7I=,tag:nLkY4ubzYLZ0DObfutFAzA==,type:str]
+    CAMERA_REOLINK_E1_ADDRESS: ENC[AES256_GCM,data:T7Xad6nhcs5pCQjmuxbQTPaa,iv:Mga8c5yT1f4cPZCbfInX4OMjGgaUYk7Prc5y/BmWCaI=,tag:RouH8qfP/rIPpjjon6O/yw==,type:str]
+    CAMERA_REOLINK_E1_USERNAME: ENC[AES256_GCM,data:dmXNzvNJIA==,iv:OQ8pfVOBxQ36ImLwy1MpNFklbkpuELrPWDr7qmj1RSM=,tag:zGELW7skJsJ02l7hPgs6DA==,type:str]
+    CAMERA_REOLINK_E1_PASSWORD: ENC[AES256_GCM,data:Pva7JGTb8xYY7yQ=,iv:3nVSZaq0C5RYMVEwCeQor9d2j2m5lCz4Lz1Wn0Pa+Ik=,tag:ETJJa1eJ9jGP1nq27kbOjg==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-05T03:15:24Z"
-    mac: ENC[AES256_GCM,data:h73k49K4WsOCjAwbZodJCF5XSRneeEVX+i2WG77vxFQ9X3tq/yRacbvrOYfGnUrU1UEEFW9747mbLDl5ZvenaHg5X2ibvrnJAgb9dKIF6t771UBNe51JjiAyWj0CTUdLiVyDiBO6QvZcN58vxrLUP6Hgw0aSNFZDPDIEJk8qVAU=,iv:DN4sv4LpNAawUhg6dirv+X2BPbBITsABkgtj0kb4ahQ=,tag:84On7HXUe2X2jI2sWXD2Ig==,type:str]
+    lastmodified: "2026-07-20T20:00:31Z"
+    mac: ENC[AES256_GCM,data:fWVD1iIKxpy9PPXMNJztfahNlvtbIW6HZZW69XmmbicRB5CsFUgSonXuuWTw5WDBTWqcMrcF6OwNtj3CP2/7Y/jOtxuyqb0X1fugUIy4Rau57iSzDdD47LKyoCfNl8iZFSHdO3MBlwf4zqS+HC0KwQuoy8cqEQW01+Upd7bzPJs=,iv:CN3OFxxH/Sewr9IfrwdStaAzSZ4ppAf4MK632PEBHb4=,tag:EViLVPntShaXSYB0737zxQ==,type:str]
     pgp:
         - created_at: "2026-06-08T03:22:24Z"
           enc: |-

--- a/services/automation/kustomization.yaml
+++ b/services/automation/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - frigate
   - namespace.yaml
   - home-assistant.yaml
+  - neolink.yaml
   - zwave-js.yaml
   #- signal-cli-rest-api.yaml
   - hermes-agent.yaml

--- a/services/automation/neolink.yaml
+++ b/services/automation/neolink.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app neolink
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+
+  values:
+    controllers:
+      app:
+        containers:
+          app:
+            image:
+              repository: quantumentangledandy/neolink
+              tag: latest@sha256:4eebf499c20f8de740d8c32163f665e41fd0f342be3b1174828b3b8bd7def59d
+            args:
+              - "rtsp"
+              - "--config"
+              - "/etc/neolink.toml"
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    service:
+      app:
+        controller: app
+        ports:
+          rtsp:
+            port: 8554
+    persistence:
+      config:
+        type: configMap
+        name: neolink-config
+        globalMounts:
+          - path: /etc/neolink.toml
+            subPath: neolink.toml
+            readOnly: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/configmap.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neolink-config
+data:
+  neolink.toml: |
+    bind = "0.0.0.0"
+    bind_port = 8554
+
+    [[cameras]]
+    name = "reolink-e1"
+    username = "${CAMERA_REOLINK_E1_USERNAME}"
+    password = "${CAMERA_REOLINK_E1_PASSWORD}"
+    address = "${CAMERA_REOLINK_E1_ADDRESS}"


### PR DESCRIPTION
## Summary

Deploy [neolink](https://github.com/QuantumEntangledAndy/neolink) to bridge the Reolink E1's proprietary Baichuan protocol to standard RTSP for Frigate.

- Camera IP `10.72.107.242` on port 9000 (Baichuan) → neolink exposes RTSP on port 8554
- ClusterIP service at `neolink.automation.svc:8554` with mount point `/reolink-e1`
- Uses `app-template` HelmRelease pattern, same as other automation services

## SOPS setup (required before merge)

Add these vars to `config/secrets.yaml`:

```
CAMERA_REOLINK_E1_ADDRESS: "10.72.107.242:9000"
CAMERA_REOLINK_E1_USERNAME: "<username>"
CAMERA_REOLINK_E1_PASSWORD: "<password>"
```

## Frigate config (manual, lives in PVC)

After neolink is running, update Frigate's `config.yml` (in the PVC):

```yaml
go2rtc:
  streams:
    reolink-e1:
      - rtsp://neolink.automation.svc:8554/reolink-e1

cameras:
  reolink-e1:
    enabled: true
    ffmpeg:
      inputs:
        - path: rtsp://127.0.0.1:8554/reolink-e1
          roles: ["detect", "record"]
```
