### PR TITLE
feat(monitoring): add OPNsense Prometheus exporter

### DIFF
--- a/platform/monitoring/dashboards/kustomization.yaml
+++ b/platform/monitoring/dashboards/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - longhorn.yaml
   - metallb.yaml
   - monitoring.yaml
+  - opnsense.yaml

--- a/platform/monitoring/dashboards/opnsense.yaml
+++ b/platform/monitoring/dashboards/opnsense.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: opnsense-exporter
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  # Ref: https://grafana.com/grafana/dashboards/21113-opnsense-exporter/
+  grafanaCom:
+    id: 21113
+    revision: 1

--- a/platform/monitoring/kustomization.yaml
+++ b/platform/monitoring/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
 - loki.yaml
 - namespace.yaml
 - oci-repositories.yaml
+- opnsense-exporter.yaml
 - prometheus-stack.yaml
 - promtail.yaml

--- a/platform/monitoring/opnsense-exporter.yaml
+++ b/platform/monitoring/opnsense-exporter.yaml
@@ -1,0 +1,124 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/secret.json
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: opnsense-exporter
+  namespace: monitoring
+stringData:
+  host: ${OPNSENSE_HOST}
+  protocol: "https"
+  api-key: ${OPNSENSE_API_KEY}
+  api-secret: ${OPNSENSE_API_SECRET}
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/deployment.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opnsense-exporter
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opnsense-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opnsense-exporter
+    spec:
+      containers:
+        - name: opnsense-exporter
+          image: ghcr.io/athennamind/opnsense-exporter:0.0.16
+          args:
+            - "--log.level=info"
+            - "--log.format=json"
+            - "--opnsense.insecure=true"
+          env:
+            - name: OPNSENSE_EXPORTER_INSTANCE_LABEL
+              value: "opnsense"
+            - name: OPNSENSE_EXPORTER_OPS_API
+              valueFrom:
+                secretKeyRef:
+                  name: opnsense-exporter
+                  key: host
+            - name: OPNSENSE_EXPORTER_OPS_PROTOCOL
+              valueFrom:
+                secretKeyRef:
+                  name: opnsense-exporter
+                  key: protocol
+            - name: OPS_API_KEY_FILE
+              value: /etc/opnsense-exporter/creds/api-key
+            - name: OPS_API_SECRET_FILE
+              value: /etc/opnsense-exporter/creds/api-secret
+          volumeMounts:
+            - name: creds
+              mountPath: /etc/opnsense-exporter/creds
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+      volumes:
+        - name: creds
+          secret:
+            secretName: opnsense-exporter
+            items:
+              - key: api-key
+                path: api-key
+              - key: api-secret
+                path: api-secret
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/service.json
+apiVersion: v1
+kind: Service
+metadata:
+  name: opnsense-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: opnsense-exporter
+spec:
+  selector:
+    app.kubernetes.io/name: opnsense-exporter
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opnsense-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opnsense-exporter
+  endpoints:
+    - port: http
+      interval: 60s
+      scrapeTimeout: 10s
+      path: /metrics


### PR DESCRIPTION
## What\n\nDeploy [AthennaMind/opnsense-exporter](https://github.com/AthennaMind/opnsense-exporter) (v0.0.16) to scrape OPNsense firewall metrics via its REST API.\n\n## Metrics collected\n\n- **Gateways** — status, RTT, packet loss, thresholds\n- **Interfaces** — bytes in/out, errors, collisions, multicast, MTU\n- **Firewall** — per-interface IPv4/IPv6 pass/block counters\n- **Services** — running/stopped status per service\n- **Firmware** — version, pending upgrades, reboot needed\n- **DHCP** — lease counts (Kea v4/v6)\n- **ARP** — table entries with IP/MAC/interface/hostname\n\nIncludes ServiceMonitor (60s scrape interval) and GrafanaDashboard ([grafana.com/21113](https://grafana.com/grafana/dashboards/21113)).\n\n## Setup required\n\nAdd the OPNsense API credentials to cluster-secrets before merging:\n\n```bash\nscripts/cluster-secrets set OPNSENSE_HOST <opnsense-ip>\nscripts/cluster-secrets set OPNSENSE_API_KEY <api-key>\nscripts/cluster-secrets set OPNSENSE_API_SECRET <api-secret>\n```\n\nThe exporter uses the existing `hermes` read-only API user — no additional OPNsense permissions needed.\n\n## Files\n\n- `platform/monitoring/opnsense-exporter.yaml` — Deployment, Service, Secret, ServiceMonitor\n- `platform/monitoring/dashboards/opnsense.yaml` — GrafanaDashboard CRD\n- Kustomization files updated for both\n