### PR TITLE
fix(database): increase postgresql-18 PVC size from 4Gi to 10Gi

### DIFF
--- a/platform/database/postgresql-18.yaml
+++ b/platform/database/postgresql-18.yaml
@@ -18,4 +18,4 @@ spec:
       memory: 2Gi
   storage:
     storageClass: longhorn
-    size: 4Gi
+    size: 10Gi


### PR DESCRIPTION
## Problem

WAL filled the 4Gi PVC during a node outage, causing CNPG to enter `Not enough disk space` phase. `postgresql-18-3` (primary) is in CrashLoopBackOff with `no free disk space for WALs`.

## Fix

Bump `spec.storage.size` from `4Gi` to `10Gi`. CNPG has `resizeInUseVolumes: true` so Longhorn will handle the live PVC resize — no downtime needed, and `postgresql-18-3` should come back up once the resize completes.

## Cluster state (pre-fix)

- `postgresql-18-1` — dangling PVC (pod gone, node went down)
- `postgresql-18-2` — healthy (only running instance)
- `postgresql-18-3` — CrashLoopBackOff (528 restarts, WAL full)