### PR TITLE
fix(database): reduce postgresql-18 instances from 3 to 2

### DIFF
--- a/platform/database/postgresql-18.yaml
+++ b/platform/database/postgresql-18.yaml
@@ -5,7 +5,7 @@ kind: Cluster
 metadata:
   name: postgresql-18
 spec:
-  instances: 3
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.0
   primaryUpdateStrategy: unsupervised
   enableSuperuserAccess: true


### PR DESCRIPTION
## Why

3 instances on a 3-node cluster means losing one node can cause WAL accumulation on the primary's PVC. The primary keeps WAL segments expecting a replica to catch up, but the replica is unreachable. With only 3 nodes and instances spread to avoid co-location, a single node failure bottlenecks the whole cluster.

Reducing to 2 instances avoids this class of failure. The remaining instance can keep writing without accumulating WAL for a dead replica.

## What

`spec.instances: 3` → `spec.instances: 2`

## Manual cleanup after merge

```bash
kubectl delete pvc postgresql-18-3 -n database
```

The postgresql-18-3 PVC is a dangling PVC (pod deleted, PVC preserved with stale WAL-filled data). Flux has `prune: false` so scaling down won't remove it — delete it manually.