### PR TITLE
feat(automation): add Routine GitHub App bot infrastructure

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -4,6 +4,11 @@ creation_rules:
   pgp: >-
     0x98C3A69E6747EA68,
     0x4B9C178B49228EFD
+- path_regex: config/routine-github-app-key.secret.yaml
+  encrypted_regex: '^(data|stringData)$'
+  pgp: >-
+    0x98C3A69E6747EA68,
+    0x4B9C178B49228EFD
 - path_regex: platform/garage/s3-keys.yaml
   encrypted_regex: '^(data|stringData)$'
   pgp: >-

--- a/config/routine-github-app-key.secret.yaml
+++ b/config/routine-github-app-key.secret.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: routine-github-app-key
+    namespace: automation
+type: Opaque
+stringData:
+    private-key: ENC[AES256_GCM,data:JwHsAabLhXs1qMH8mEnEbubQuF82rzrsFWLdYa8ootTYjEKL4cjrcUG8getSxnjJq7NSd6rUt+OGs/liIN9DB/lxWjaRUXYzd/kpTBA7xIoEHmtMTUIxs2T5++e4QAV8k+O/1jdpsTxWxEL8bvpzNyOabPTQnL5HuTjGbj4Okd4XJPBrcPlhzAKl2FPZD9cXMEffFoxVKRaSOAn/cI34PL8QJtskrOWSIb9xAkXm/SQpM52wfdi225MQ7pPmujKAXWnjA13rBKD8t5BLl1Q3dIxhUEhPqBrdPrY3RMWtVbmsrp5GF/IhB3hbcwX07WxMjVjE2V3yzb/C1n9xWI74uC4TztPqm+Sv1/TxcGbeAANpNXgK2qu7py6EU7E1QYiqWf2LelrSoayjsNsUd+5PGC+YP9A05dbHe/oEt1Rb7AdA6Op7oevgiQMX3zXCqU+s00EH/bRhUjs2z20aAJqdbpBpz/baeG+2Hj824Y0G6GiUoEXOqx/uIQFC0IfadI7Rvy0eKOZKBBJ3nSffBfo1AEXtwYw3q5tpm7ZQJ4iXxvyUsBfJAv2srDYpD6c8tvyufaA1+wsRj/LscIkTgpIqb0QshV6sMAvWVldjIArcmlFE2qp8ig7AyTvIV5Dcj8F6KK8jGK8IUWA51ol4fgQH9q/V0gkiKXEtqLqAg3i5GApY0SAwr+2RH1ntuSOO9C9WYvkkY9j3QoR8Ds9lt9iaFarBzgd2OfRlsIgq+XE9KyzcY6oRzBdEnj4+XJZCtmg1oLb46OFXaxq7laisTmDC3idyW1PCY9nw9cgYaE6FMSbyQnpf2TM77GOX8eMARGILeIAl/96hydvBtbOKjFsWRBuM1lwtdWZOb4ZKgcFvIR9RG3gUKXk0NTn34zQMKD19AwGBxJWZr7NAQjx4CBTHUjmBJIeP8XvcIx0IOk4DMfqJqYfMA0ok1go/b1mqvo9KryfiaZhppsu/RwoGy22HDl1KXu8faVl42vhSxpDsEKAboP/GLabr0ATnsFN3vdzo2dAZrLKYbYNDHwkKJPkTZ84+PQWXZ8YY5xT8MU7i6/tClnF8zsfVUHmHtW8Lnan9r5FxGZMiRH+6xz/3rakaRfzvZeKAMikBYpGlfxPZ/X7MhGi9ZPnzGgM9EQoKb7M+rBGis7Ruj6zxERlxOTfGL3TEt+3Bq9PsvJgPm6qWN7dViA+ETCdSEFgdQdAxsU76O78zXA9tYZFPo94EXZr/ceGdZyddbsGC/siQe7dn/F4vImOF7z7VSAzkipoLqbug98J5QnZW6e5D5yHeXX8y+E2gyr2YVu0LxIeuk1stt6iyPiYx1l0BQoLjSGqpYiyvAeM9/npzJTEG/efpcin61wO8L6/H3BFWL8t85pN1LW0Pjiw4uUX6XYNlJrfts/8YGrudrsFu5FU2Q2/pUWngYdGFjoGj3T7oc+pkdG33xEnjYlHlzZMqots3Yt1MGAhwrNd51JJU27seIJQQVdr+KAPbZALnucK2bT7QObOER9hMhl/ikGbEbY8/G5vtPFslBMahWu+1kL/lU0CNZ/vliL+6sgaeM/3eyUHLzzUOGL+d5TbgANAB89mSIzBriUfLLJ1s/T8MjgZ+2QpMhN0c+WQrfFBumGWcopuonwP67DDYuv1vch1ZH5i06AXt495nSmpqT/hAAsP5zLT2VXXnbcH74n/eOAweY1XMuj7vuwwTaEcIby20kQ7dsvdqQZaiTc5cm+Jqr2qpDNRuf2jI15paRM1YZ3wFQUlBoscswOWhKB3ZCX/VGHELiva69vWGnUrScmxnu69TYFrIIKVmCYZe3KEbJZya89dTY5XeyLfAP4Ionc0yx1RpRwSKZ341lJzXmVSBAe9JS5wZBchLZX6kqfR2wtpKofajXyOsdKirjtjRs7yuBBll/9idQHBjDHZiuEVayutg+UtPqTaw4y2dqZZ5UGK4iUYGni6RZfTqdvDKf9DinX5y7/fhWwo10gZdFbg1ho1k6UQQK3mFnSKE5HAcUOZNQdGGB9Qc5zNPJJ/eskmo+1KCJqvtGql3xOMx9fJIeRKRUbTDG9BItjdS/VO9VOhin/M7H0prmTnRU42xlS0mEFe7UKIuXFdpc0hpXDCLIUSFGB+dD83E14GiOJ3eZX4FJbOrXK/ve+n9URTuYZ6HlFRrCTbvsxFlisiftfvMANu952Hb65xNLlA0B1qHjZutpgfEaMhVopu0I0KQuST68VsCIgUG1hU=,iv:Ptbiwq1QdfNCPs1CkXB7RtgEt2f+yhIdVcD1FJtrtNI=,tag:ahpsgZRLuKYzXMbYeuCIqg==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-25T21:08:54Z"
+    mac: ENC[AES256_GCM,data:gwUjyFG5y6QfdN5RWiHS32MjsohU6hCs9Lm6bF55S37c4PpV5hb6tWBuGgxbZe/H7Peb7nwBVcmRtNE61nxvyZJaJ2CW8HTbLNj9MOCrjvXJ5et/FDCQS7QIxoZUzhQJU+hTNWSezK3+DwANHALlw2P2OTIZWPcAstwq5cGZmnM=,iv:Qo9EgO9I8VSXIegAb42R+w+2NHqsK8fLUi3xYwFDZRU=,tag:T8PP1B8F7Oy86UtMDKYalw==,type:str]
+    pgp:
+        - created_at: "2026-07-25T21:08:54Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DK2T0oPsKQSoSAQdATOfN9mqhW8EhhD2OWBcq9FkVfSejdaiFNvy8yP9WlHMw
+            amQNOGDtp6STocW2rX4EYMxfYZrxSqbEKA2tOgqkaCFss7ZKHoTgwkMd+k+AdCes
+            0l4BRhie6Z7IIGiFXlOMmC51yneCp+HC8HbBv/tl43a3kUAWXRZjWmVVxMSQ1WYc
+            m6QMoWLV/l2sX/NAUXD3YlY791tj9Gu1JDHvjwsCGjFMn1lBbAsmTWsqHuw7JUrT
+            =6dbD
+            -----END PGP MESSAGE-----
+          fp: "0x98C3A69E6747EA68"
+        - created_at: "2026-07-25T21:08:54Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DiZ7E0TI8O2gSAQdA7a6OsENI0jPvTUVesToHl/TdZlWnyu5UytLLljel7zQw
+            o2fKJofLFzVfHSf3Wg9aIPv47QM2Q8LDix5vF/KMo7SuAio4z60gKvY1A7B5T6ZQ
+            0l4B3Y/++7C4zVBkTgyiP9emvZy3Q3QU2tbDTMkHdOhNMM4yRuZgQI7bUQRl4fsG
+            7wExEp4lSz/Ub2++Y16zuxdN89mRDMwETPsv9znq4qNpFntSypa7XSdNmdhqZ0jy
+            =vBi/
+            -----END PGP MESSAGE-----
+          fp: "0x4B9C178B49228EFD"
+    version: 3.13.0

--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -129,10 +129,11 @@ stringData:
     OPNSENSE_HOST: ENC[AES256_GCM,data:v7yIY9XXNcUgUw==,iv:z5I/7bBI58lw4v1YK0CWMZNv7S43YZVn1Oh5XWgvEjk=,tag:qHEeAaSs13kl5akBRP8tig==,type:str]
     OPNSENSE_API_KEY: ENC[AES256_GCM,data:9dQTpouNiEVyi9J3v0gwq0IwEI2OvTA8czRLl3NYYMo45Ev0fXaeBLMqPCg+rSV1dsrVeYJCZ2ZOGZhQ906abRRbu59LOKFcWLr7WNyQ1o0=,iv:xvXS6k7qHMwJ2RJj2M3TFm+7up3BVqItHye0bS0DQcA=,tag:724AwQSzJa9bxML6xNM/+A==,type:str]
     OPNSENSE_API_SECRET: ENC[AES256_GCM,data:iiNbDAJ5NR5O1uGk2rMgOG5YOSGMe5Pvn7o2y58OEBaQZr+f9j1cCD6vkfnzszEUpte/ciAMxiDKF8pQ6vo909sJPk8EJ1asp5hj+cvBYLo=,iv:wJBWkKbHDlgFdOBqReW3fV0sD59slBHgYzMjNUCHaGM=,tag:4lpoWKhVuAxBCxMWg+SMrw==,type:str]
+    GITHUB_ROUTINE_APP_ID: ENC[AES256_GCM,data:ZzyGq8CKJg==,iv:g43jhrElNVKHWhe0MDzxTzSKxt5JAS7bz1ZtTAzZTww=,tag:OGcAGOWdK6O2kPRtKXsb8Q==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-25T05:49:46Z"
-    mac: ENC[AES256_GCM,data:DQeDW18wI8aSN4lLDHjCTOtpFRgiyc0d3CTOGXJyrAQGSjKN5hBo6PGFchgtJP06boJ5imfWBhVcmqnDI+uwWGV7t3Ml2LAodUpJSsBdyDFH6c3Bui87qCnNk7T/sX7jJS2r5UKD2G5JdlN0oNPko/Scy+qpHebtEZBlnGq4Xa8=,iv:vNtzh37wRUY71Y96ITTFUXBYGlFpOVRsyPcxax+Dhv4=,tag:gQi7ZoZuVoJl54G/5K1IFg==,type:str]
+    lastmodified: "2026-07-25T21:08:54Z"
+    mac: ENC[AES256_GCM,data:I11DvRhTB7HHRfzqbmEPCJ6epj6CUmblrzk71HrmEweFbMja76c3ekM8ZWOtJr4daatxrzk1b29s0ecTy7r/STSB5aMkyM8KGuFKpu1+EZ1Gjh7mydnycGcmpnifo/l6dKyqg2WHtYK3guyxktvIsi1BI0wQSoxb/5LkGXv4Qe4=,iv:soJpdtyrelS+30+yWtNIJC5iVQbkP9+HtacSmSzjO3k=,tag:Lqa2v1zINhL6XPeVIM/Kfw==,type:str]
     pgp:
         - created_at: "2026-06-08T03:22:24Z"
           enc: |-

--- a/core/kustomization.yaml
+++ b/core/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../config/secrets.yaml
+- ../config/routine-github-app-key.secret.yaml
 - autopilot.yaml
 - operators
 - repositories

--- a/docs/github-app-routine.md
+++ b/docs/github-app-routine.md
@@ -1,0 +1,168 @@
+# Routine — GitHub App for Hermes Agent
+
+Routine is a GitHub App that gives Hermes Agent its own bot identity on GitHub.
+It acts as `routine[bot]` in comments, commits, and PRs — separate from any
+personal account.
+
+## App Manifest
+
+```yaml
+# github-app-manifest.yaml — use this to create or recreate the app
+name: Routine
+description: Hermes Agent bot for PRs, issues, and repo operations
+url: https://hermes.zro.io
+hook_attributes:
+  url: https://hermes-webhook.zro.io/webhooks/github
+  active: false  # webhooks are managed separately via Hermes subscriptions
+public: false
+default_permissions:
+  contents: read
+  issues: write
+  pull_requests: write
+  metadata: read
+default_events: []
+```
+
+## Creating the App (one-time setup)
+
+### Option A: GitHub UI
+
+1. Go to https://github.com/settings/apps/new
+2. Fill in:
+   - **GitHub App name**: `Routine`
+   - **Homepage URL**: `https://hermes.zro.io`
+   - **Webhook URL**: `https://hermes-webhook.zro.io/webhooks/github`
+   - **Webhook secret**: (generate a random string, or leave blank — Hermes manages
+     its own HMAC per subscription)
+3. Under **Permissions**, set:
+   - **Contents**: Read-only
+   - **Issues**: Read & write
+   - **Pull requests**: Read & write
+   - **Metadata**: Read-only (auto-selected)
+4. Under **Where can this GitHub App be installed?**, select **Any account**
+5. Click **Create GitHub App**
+6. After creation, scroll to **Private keys** and click **Generate a private key**.
+   Save the `.pem` file.
+7. Note the **App ID** (top of the page).
+
+### Option B: Manifest flow (API)
+
+```bash
+# 1. Navigate to the manifest creation URL (opens in browser):
+#    https://github.com/settings/apps/new?state=abc123
+
+# 2. Paste the manifest YAML above into the text area.
+
+# 3. After creation, generate a private key and note the App ID.
+```
+
+### Installing on Repos
+
+1. Go to the app's page: `https://github.com/apps/routine`
+2. Click **Install** (or `https://github.com/apps/routine/installations/new`)
+3. Choose **Only select repositories** and pick the repos Routine should access:
+   - `zacheryph/*` — personal repos
+   - `ecogistics/*` — contract repos
+4. You can install on multiple accounts/orgs. Each installation gets its own
+   Installation ID, but you don't need to record them — Routine discovers the
+   correct one at runtime (see below).
+
+### How Installation IDs Work
+
+When you install a GitHub App on an account or org, GitHub assigns an
+**Installation ID**. If you install Routine on both `zacheryph` and `ecogistics`,
+you'll have two installation IDs — one per account.
+
+**You do not need to store these.** The GitHub API provides a dynamic lookup:
+
+```
+GET /repos/{owner}/{repo}/installation
+```
+
+Given any repo the app is installed on, this returns the correct Installation ID.
+Routine authenticates with its App JWT (generated from the App ID + private key),
+calls this endpoint, and gets back the right Installation ID for the repo it's
+about to operate on.
+
+This means you only need to store two things:
+- **App ID** — public identifier for the app
+- **Private key** — the secret used to sign JWTs
+
+### Storing Credentials in k8s-gitops
+
+Run the setup script from the repo root:
+
+```bash
+scripts/routine-github-app setup
+```
+
+The script prompts for:
+- **App ID** — numeric, from the app's settings page
+- **Private key path** — path to the `.pem` file downloaded from GitHub
+
+It stores them across two files (both SOPS-encrypted):
+
+| File | Value | Why separate |
+|---|---|---|
+| `config/secrets.yaml` | `GITHUB_ROUTINE_APP_ID` | Single-line, safe for `sops --set` |
+| `config/routine-github-app-key.secret.yaml` | PEM private key | Multi-line block scalar — `sops --set` can't handle newlines in JSON values |
+
+The PEM key lands in a dedicated Kubernetes Secret (`routine-github-app-key`)
+and is mounted at `/etc/routine-github-app/key.pem` with mode `0o600`.
+
+After setup, commit and push:
+
+```bash
+git add config/secrets.yaml config/routine-github-app-key.secret.yaml
+git commit -m "chore(secrets): add Routine GitHub App credentials"
+git push
+```
+
+Flux will reconcile and the Hermes pod will pick up the new secret on restart.
+
+## Verification
+
+```bash
+# Check the secret exists in cluster
+kubectl get secret routine-github-app-key -n automation
+
+# Check the App ID env var is set in the Hermes pod
+kubectl exec -n automation deploy/hermes-agent -- env | grep GITHUB_ROUTINE_APP_ID
+
+# Check the PEM key is mounted
+kubectl exec -n automation deploy/hermes-agent -- ls -la /etc/routine-github-app/key.pem
+
+# Test gh auth as the bot (from inside the pod)
+kubectl exec -n automation deploy/hermes-agent -- \
+  gh auth status 2>&1 || echo "gh not configured for bot yet"
+```
+
+## How Auth Works
+
+1. **Sign a JWT** using the App ID + private key (`/etc/routine-github-app/key.pem`)
+2. **Discover installation ID** via `GET /repos/{owner}/{repo}/installation` (JWT-auth'd)
+3. **Exchange** JWT for an installation token via `POST /app/installations/{id}/access_tokens`
+4. **Use the token** like a PAT for API calls (expires in 1 hour)
+
+## Rotating the Private Key
+
+1. Generate a new private key on the app's settings page
+2. Run: `scripts/routine-github-app update-key /path/to/new-key.pem`
+3. Commit and push
+4. The old key continues working until the app revokes it (GitHub allows multiple
+   active keys).
+
+## Installing on Additional Orgs Later
+
+Just install the app on the new org via `https://github.com/apps/routine/installations/new`.
+No credential changes needed — the dynamic installation ID lookup handles it
+automatically.
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| `gh auth status` shows personal account, not bot | The `GITHUB_TOKEN` env var or `gh` host config is overriding the app. The app credentials are available as `GITHUB_ROUTINE_APP_ID` env var and `/etc/routine-github-app/key.pem` — the Hermes GitHub skill needs to be updated to use them. |
+| Private key PEM has wrong permissions | The `extraVolumes` mount sets `defaultMode: 0o600`. If you see permission errors, check the Secret's `stringData` preserves the PEM format (no extra escaping). |
+| Installation token expired | Installation tokens expire after 1 hour. The app/client must refresh by generating a new JWT and exchanging it. This is handled by the GitHub API client, not the secret itself. |
+| 404 on installation lookup | The app isn't installed on that repo's account. Install it at `https://github.com/apps/routine/installations/new`. |

--- a/scripts/routine-github-app
+++ b/scripts/routine-github-app
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Manage Routine GitHub App credentials.
+#
+# Two credential stores are involved:
+#   1. config/secrets.yaml (SOPS-encrypted, via sops --set)
+#      → GITHUB_ROUTINE_APP_ID (single-line, public — sops --set handles this fine)
+#
+#   2. config/routine-github-app-key.secret.yaml (SOPS-encrypted standalone Secret)
+#      → The PEM private key, stored as a YAML block scalar so multi-line
+#        newlines are preserved. sops --set cannot handle multi-line values
+#        (it requires valid JSON), so this file is created as plain YAML then
+#        encrypted in-place.
+#
+# Installation IDs are discovered dynamically via the GitHub API
+# (GET /repos/{owner}/{repo}/installation) — no need to store them.
+#
+# Usage:
+#   routine-github-app setup                   # interactive: App ID + PEM path
+#   routine-github-app show                    # decrypt and print current values
+#   routine-github-app update-key <pem-file>   # rotate the private key
+#   routine-github-app remove                  # remove all Routine keys
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SECRETS="$REPO_ROOT/config/secrets.yaml"
+PEM_SECRET="$REPO_ROOT/config/routine-github-app-key.secret.yaml"
+
+_ensure_encrypted() {
+  if ! grep -q 'sops:' "$SECRETS" 2>/dev/null; then
+    echo "==> Encrypting $SECRETS with SOPS..."
+    sops --encrypt --in-place "$SECRETS"
+  fi
+}
+
+_write_pem_secret() {
+  local pem_path="$1"
+  local pem_file="$PEM_SECRET"
+
+  # Create a plain YAML Secret with the PEM as a block scalar.
+  # SOPS will encrypt the stringData section in-place.
+  cat > "$pem_file" <<'YAML_HEADER'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: routine-github-app-key
+  namespace: automation
+type: Opaque
+stringData:
+  private-key: |
+YAML_HEADER
+
+  # Indent every line of the PEM by 4 spaces (YAML block scalar continuation)
+  sed 's/^/    /' "$pem_path" >> "$pem_file"
+
+  echo "==> Encrypting $pem_file with SOPS..."
+  sops --encrypt --in-place "$pem_file"
+  echo "==> Encrypted."
+}
+
+cmd_setup() {
+  echo "=== Routine GitHub App Setup ==="
+  echo ""
+
+  # App ID (public identifier — single line, safe for sops --set)
+  read -r -p "App ID: " app_id
+  if [[ -z "$app_id" ]]; then
+    echo "ERROR: App ID is required" >&2
+    exit 1
+  fi
+
+  # Private key PEM file (multi-line — stored as standalone SOPS Secret)
+  read -r -p "Path to private key .pem file: " pem_path
+  if [[ ! -f "$pem_path" ]]; then
+    echo "ERROR: $pem_path not found" >&2
+    exit 1
+  fi
+
+  # Store App ID in cluster-secrets
+  _ensure_encrypted
+  echo ""
+  echo "==> Storing App ID in $SECRETS..."
+  sops --set '["stringData"]["GITHUB_ROUTINE_APP_ID"] "'"$app_id"'"' "$SECRETS"
+
+  # Store PEM in standalone SOPS-encrypted Secret
+  echo "==> Storing private key in $PEM_SECRET..."
+  _write_pem_secret "$pem_path"
+
+  echo ""
+  echo "==> Done."
+  echo ""
+  echo "Files created/updated:"
+  echo "  config/secrets.yaml                             — GITHUB_ROUTINE_APP_ID"
+  echo "  config/routine-github-app-key.secret.yaml       — private key PEM"
+  echo ""
+  echo "Installation IDs are discovered dynamically via the GitHub API"
+  echo "(GET /repos/{owner}/{repo}/installation) — no need to store them."
+  echo ""
+  echo "Next steps:"
+  echo "  1. git add config/secrets.yaml config/routine-github-app-key.secret.yaml"
+  echo "  2. git commit -m 'chore(secrets): add Routine GitHub App credentials'"
+  echo "  3. git push"
+  echo "  4. Flux will reconcile — Hermes picks up the new secret on restart"
+}
+
+cmd_show() {
+  echo "=== Routine GitHub App Credentials ==="
+  echo ""
+
+  if grep -q 'sops:' "$SECRETS" 2>/dev/null; then
+    app_id=$(sops --decrypt --extract '["stringData"]["GITHUB_ROUTINE_APP_ID"]' "$SECRETS" 2>/dev/null || echo "(not set)")
+    echo "App ID: $app_id"
+  else
+    echo "App ID: (config/secrets.yaml not encrypted yet)"
+  fi
+  echo ""
+
+  if [[ -f "$PEM_SECRET" ]]; then
+    echo "Private key (first/last 3 lines):"
+    sops --decrypt "$PEM_SECRET" 2>/dev/null | sed -n '/private-key: |/,$ p' | tail -n +2 | head -3
+    echo "..."
+    sops --decrypt "$PEM_SECRET" 2>/dev/null | sed -n '/private-key: |/,$ p' | tail -n +2 | tail -3
+  else
+    echo "Private key: (not yet created — run 'routine-github-app setup')"
+  fi
+}
+
+cmd_update_key() {
+  local pem_path="${1:?Usage: routine-github-app update-key <pem-file>}"
+  if [[ ! -f "$pem_path" ]]; then
+    echo "ERROR: $pem_path not found" >&2
+    exit 1
+  fi
+
+  echo "==> Updating private key in $PEM_SECRET..."
+  _write_pem_secret "$pem_path"
+
+  echo "==> Private key updated."
+  echo ""
+  echo "Next steps:"
+  echo "  1. git add config/routine-github-app-key.secret.yaml"
+  echo "  2. git commit -m 'chore(secrets): rotate Routine GitHub App private key'"
+  echo "  3. git push"
+}
+
+cmd_remove() {
+  # Remove App ID from cluster-secrets
+  if grep -q 'sops:' "$SECRETS" 2>/dev/null; then
+    sops unset --idempotent "$SECRETS" '["stringData"]["GITHUB_ROUTINE_APP_ID"]' 2>/dev/null || true
+    echo "==> Removed GITHUB_ROUTINE_APP_ID from config/secrets.yaml"
+  fi
+
+  # Remove PEM secret file
+  if [[ -f "$PEM_SECRET" ]]; then
+    rm "$PEM_SECRET"
+    echo "==> Removed config/routine-github-app-key.secret.yaml"
+  fi
+
+  echo ""
+  echo "Next steps:"
+  echo "  1. git add config/secrets.yaml config/routine-github-app-key.secret.yaml"
+  echo "  2. git commit -m 'chore(secrets): remove Routine GitHub App credentials'"
+  echo "  3. git push"
+}
+
+case "${1:-}" in
+  setup)      cmd_setup ;;
+  show)       cmd_show ;;
+  update-key) shift; cmd_update_key "$@" ;;
+  remove)     cmd_remove ;;
+  *)
+    sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# //'
+    exit 1
+    ;;
+esac

--- a/services/automation/hermes-agent.yaml
+++ b/services/automation/hermes-agent.yaml
@@ -98,6 +98,7 @@ spec:
       SIGNAL_ALLOWED_USERS: ${HERMES_SIGNAL_ALLOWED_USERS}
       HERMES_YOLO_MODE: "1"
       HERMES_WRITE_SAFE_ROOT: /opt/data:/tmp
+      GITHUB_ROUTINE_APP_ID: ${GITHUB_ROUTINE_APP_ID}
 
     # Secrets rendered into a Kubernetes Secret by the chart
     secrets:
@@ -106,6 +107,12 @@ spec:
       SLACK_APP_TOKEN: ${HERMES_SLACK_APP_TOKEN}
       API_SERVER_KEY: ${HERMES_API_SERVER_KEY}
       WEBHOOK_SECRET: ${HERMES_WEBHOOK_SECRET}
+
+    # Mount Routine GitHub App private key at /etc/routine-github-app/key.pem
+    extraVolumeMounts:
+      - name: routine-github-app-key
+        mountPath: /etc/routine-github-app
+        readOnly: true
 
     persistence:
       enabled: true
@@ -239,3 +246,7 @@ spec:
           defaultMode: 0o600
       - name: obsidian-config
         emptyDir: {}
+      - name: routine-github-app-key
+        secret:
+          secretName: routine-github-app-key
+          defaultMode: 0o600


### PR DESCRIPTION
## Summary

Adds the GitOps-managed definition for **Routine** — a GitHub App that lets Hermes Agent interact with GitHub as a bot (`routine[bot]`) instead of using a personal account.

## Design decisions

### Installation IDs: dynamic lookup, not stored

The GitHub API can discover installation IDs at runtime via `GET /repos/{owner}/{repo}/installation`. Only two values are stored:

| Value | Storage | Why |
|---|---|---|
| App ID | `config/secrets.yaml` (via `sops --set`) | Single-line, safe for `sops --set` |
| PEM private key | `config/routine-github-app-key.secret.yaml` (standalone SOPS file) | Multi-line block scalar — `sops --set` cannot handle raw newlines in JSON values |

The PEM file is a full Kubernetes Secret YAML with the key as a `|` block scalar. SOPS encrypts the `stringData` section in-place. This preserves the exact PEM format with proper newlines — no JSON escaping, no base64, no `\n` drift.

### Auth flow

```
App ID (env var) + /etc/routine-github-app/key.pem (mounted file)
  → sign JWT
  → GET /repos/{owner}/{repo}/installation   (discover installation ID)
  → POST /app/installations/{id}/access_tokens  (get 1-hour token)
  → use token for GitHub API calls
```

## What this PR adds

### 1. `docs/github-app-routine.md`
Full runbook with the GitHub App manifest, step-by-step creation instructions, installation guide, auth flow explanation, and troubleshooting.

### 2. `scripts/routine-github-app`
Interactive setup script:
- `routine-github-app setup` — prompts for App ID + PEM path
- `routine-github-app show` — decrypt and display current values
- `routine-github-app update-key <pem>` — rotate the private key
- `routine-github-app remove` — remove all Routine keys

### 3. `config/routine-github-app-key.secret.yaml`
Created by the setup script (not committed — contains the encrypted PEM). Referenced by `core/kustomization.yaml` and encrypted via the new `.sops.yaml` rule.

### 4. `.sops.yaml` + `core/kustomization.yaml`
SOPS encryption rule for the new file, and kustomization resource entry so Flux picks it up.

### 5. `services/automation/hermes-agent.yaml`
- `GITHUB_ROUTINE_APP_ID` — plain env var (public identifier)
- `extraVolumeMounts` — PEM mounted at `/etc/routine-github-app/key.pem`
- `extraVolumes` — references the `routine-github-app-key` Secret (from the standalone file)

## Setup after merge

```bash
# 1. Create the Routine GitHub App (one-time)
#    Follow docs/github-app-routine.md or go to:
#    https://github.com/settings/apps/new

# 2. Run the setup script from the repo root:
scripts/routine-github-app setup

# 3. Commit and push the encrypted secrets:
git add config/secrets.yaml config/routine-github-app-key.secret.yaml
git commit -m "chore(secrets): add Routine GitHub App credentials"
git push

# 4. Flux reconciles → Hermes pod restarts → credentials available
```

## What's NOT in this PR (follow-up)

- Hermes Agent doesn't yet _use_ these credentials — this PR makes them available in the pod. A separate change will teach Hermes to do the JWT → installation ID → token flow.
- No webhook events are configured on the app yet — the manifest sets `default_events: []` and `hook_attributes.active: false`.