### PR TITLE
fix(opnsense-exporter): drop spurious =true from --opnsense.insecure boolean flag

### DIFF
--- a/platform/monitoring/opnsense-exporter.yaml
+++ b/platform/monitoring/opnsense-exporter.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - "--log.level=info"
             - "--log.format=json"
-            - "--opnsense.insecure=true"
+            - "--opnsense.insecure"
           env:
             - name: OPNSENSE_EXPORTER_INSTANCE_LABEL
               value: "opnsense"


### PR DESCRIPTION
## Root cause

The opnsense-exporter Deployment passes `--opnsense.insecure=true` as a container arg, but `--opnsense.insecure` is a boolean flag that does not accept a value. The Go flag parser splits this into `--opnsense.insecure` (sets the flag) + `true` (unexpected positional argument), causing:

```
opnsense-exporter: error: unexpected true, try --help
```

The container has been in CrashLoopBackOff with 99 restarts.

## Fix

Drop the `=true` suffix — the flag is boolean, presence alone is sufficient.

## Verification

- Pod log captured from the live cluster confirms the exact error
- The exporter only needs `--opnsense.insecure` to skip TLS verification against the OPNSense self-signed cert (protocol is already set to `https` via env var)