### PR TITLE
feat(garage): publish public bucket web endpoint to external DNS

### DIFF
--- a/platform/garage/kustomization.yaml
+++ b/platform/garage/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - bootstrap.yaml
   - configuration.yaml
   - namespace.yaml
+  - public-httproutes.yaml
   - release.yaml
   - s3-keys.yaml
   - webui.yaml

--- a/platform/garage/public-httproutes.yaml
+++ b/platform/garage/public-httproutes.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garage-public-web
+  namespace: garage
+  annotations:
+    dns.routine.sh/external: "true"
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+  hostnames:
+    - "public.${WEB_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: garage
+          port: 3902


### PR DESCRIPTION
## What

Add a standalone HTTPRoute for the `public` Garage bucket web hostname with the `dns.routine.sh/external: "true"` annotation so ExternalDNS Cloudflare publishes the DNS record — for that bucket only.

## Why

The `public` bucket exists in Garage bootstrap config and the existing wildcard web route (`*.${WEB_DOMAIN}`) already routes bucket subdomains to Garage's web server (port 3902). But ExternalDNS Cloudflare is opt-in only (`--annotation-filter=dns.routine.sh/external=true`), and no route had the annotation for the public bucket hostname.

The wildcard route stays internal-only. This PR adds a separate, scoped HTTPRoute that only covers the public bucket.

## Change

Two files:

1. **New:** `platform/garage/public-httproutes.yaml` — standalone HTTPRoute for `public.${WEB_DOMAIN}` → `garage:3902` with `dns.routine.sh/external: "true"`
2. **Modified:** `platform/garage/kustomization.yaml` — adds `public-httproutes.yaml` to resources

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: garage-public-web
  namespace: garage
  annotations:
    dns.routine.sh/external: "true"
spec:
  parentRefs:
    - name: external
      namespace: gateway
  hostnames:
    - "public.${WEB_DOMAIN}"
  rules:
    - backendRefs:
        - name: garage
          port: 3902
```