### PR TITLE
feat(monitoring): add smartctl exporter Grafana dashboard

### DIFF
--- a/platform/monitoring/dashboards/kustomization.yaml
+++ b/platform/monitoring/dashboards/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - metallb.yaml
   - monitoring.yaml
   - opnsense.yaml
+  - smartctl-exporter.yaml

--- a/platform/monitoring/dashboards/smartctl-exporter.yaml
+++ b/platform/monitoring/dashboards/smartctl-exporter.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: smartctl-exporter
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  # Ref: https://grafana.com/grafana/dashboards/22604-smartctl-exporter-dashboard/
+  grafanaCom:
+    id: 22604
+    revision: 3


### PR DESCRIPTION
## Summary
- provision Grafana dashboard 22604 (SMARTctl Exporter Dashboard), revision 3
- map the dashboard Prometheus input to the existing `prometheus` datasource
- include the dashboard in the monitoring dashboards kustomization

## Validation
- `git diff --check` passed
- manifest follows existing Grafana Operator dashboard conventions

Note: local kustomize rendering was unavailable because `kubectl` is not installed in the execution environment.