### PR TITLE
feat(forgejo): add actions runner for CI

### DIFF
--- a/.hermes/plans/2026-08-27_090000-forgejo-actions-runner.md
+++ b/.hermes/plans/2026-08-27_090000-forgejo-actions-runner.md
@@ -1,0 +1,77 @@
+# Forgejo Runner Implementation Plan
+
+> **For Hermes:** Implemented in `services/development` as a Flux OCI HelmRelease.
+
+**Goal:** Deploy a Forgejo Actions runner so Forgejo can execute CI jobs. The runner and all job pods run in a dedicated `forgejo-runner` namespace for isolation from the main `development` workload.
+
+**Architecture:** Use the upstream `forgejo-runner` chart from the plugin author (`oci://git.erwanleboucher.dev/eleboucher/charts/forgejo-runner`, chart v12.10.9). The chart runs the Forgejo runner (v12 fork with Kubernetes backend support) alongside its native gRPC k8s plugin as a native sidecar (initContainer with `restartPolicy: Always`; requires Kubernetes 1.29+, cluster is on 1.36). Each CI job is created as an ephemeral pod in the `forgejo-runner` namespace via in-cluster ServiceAccount — no Docker-in-Docker, no privileged containers.
+
+- Runner daemon fetches jobs over the internal forgejo-http service; registration UUID/token come from `cluster-secrets` (`FORGEJO_RUNNER_UUID`, `FORGEJO_RUNNER_TOKEN`) substituted into a plain Secret manifest (same pattern as `opnsense-exporter`).
+- Chart RBAC grants the runner's ServiceAccount jobs/pods permissions only inside its own namespace.
+- Labels exposed to workflows: `ubuntu-latest` and `default`, running `ghcr.io/bjw-s-labs/forgejo-runner:ubuntu-24.04` job pods, digest-pinned, capped at 2 concurrent jobs with resource limits.
+- No HTTPRoute: the runner makes only outbound connections (fetch + cache proxy on localhost).
+
+**Tech Stack:** Flux OCIRepository + HelmRelease, eleboucher forgejo-runner chart, bjw-s runner-k8s-plugin sidecar.
+
+---
+
+### Task 1: Register the upstream OCI chart
+
+**Files:**
+- Create: `services/development/forgejo-runner-repo.yaml`
+
+Add an OCIRepository named `forgejo-runner` pointing to `oci://git.erwanleboucher.dev/eleboucher/charts/forgejo-runner`, pinned to chart version `12.10.9`.
+
+### Task 2: Add the namespace
+
+**Files:**
+- Modify: `services/development/forgejo-runner.yaml`
+
+Add a Namespace `forgejo-runner`. It is not `privileged`-labeled: nothing here needs elevated pods.
+
+### Task 3: Registration Secret
+
+**Files:**
+- Create: `services/development/forgejo-runner-secret.yaml`
+
+Plain Secret `forgejo-runner-registration` in namespace `forgejo-runner` with keys `uuid` / `token` populated through `${FORGEJO_RUNNER_UUID}` / `${FORGEJO_RUNNER_TOKEN}` cluster-secrets substitution.
+
+### Task 4: HelmRelease
+
+**Files:**
+- Modify: `services/development/forgejo-runner.yaml`
+
+Configure:
+- `forgejo.url`: internal service URL for the existing Forgejo instance
+- `forgejo.existingSecret`: `forgejo-runner-registration`
+- runner image `registry.erwanleboucher.dev/eleboucher/runner:12.13.0`
+- `runnerConfig` with plugin socket `unix:///plugin/forgejo-runner-k8s.sock`, plugin options targeting the release namespace, cache enabled, capacity 2
+- `podSpecs` default podspec with digest-pinned job image and cpu/memory requests+limits
+- runner resources requests/limits
+- keep chart defaults for RBAC (namespaced Role/RoleBinding), non-root securityContext, reloader annotation
+
+### Task 5: Wire into Kustomization
+
+**Files:**
+- Modify: `services/development/kustomization.yaml`
+
+Add `forgejo-runner.yaml`, `forgejo-runner-secret.yaml`, and `forgejo-runner-repo.yaml` to resources.
+
+### Task 6: Validate and inspect
+
+Run:
+```bash
+kubectl kustomize services/development/ >/dev/null && echo OK
+git diff --check && git diff --stat
+```
+
+Post-merge verification:
+```bash
+flux reconcile kustomization services-development --with-source
+flux get helmreleases -n forgejo-runner
+kubectl -n forgejo-runner get pods   # runner Ready 2/2 (runner + plugin sidecar)
+# trigger a test workflow in any repo:
+#   .forgejo/workflows/ci.yaml with runs-on: ubuntu-latest
+```
+
+Note: after merging, create an image pull secret only if ghcr rate limits become a problem — not needed initially since both images are public.

--- a/services/development/forgejo-runner-repo.yaml
+++ b/services/development/forgejo-runner-repo.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgejo-runner
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 12.10.9
+  url: oci://git.erwanleboucher.dev/eleboucher/charts/forgejo-runner

--- a/services/development/forgejo-runner-repo.yaml
+++ b/services/development/forgejo-runner-repo.yaml
@@ -4,6 +4,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: forgejo-runner
+  namespace: flux-system
 spec:
   interval: 12h
   layerSelector:

--- a/services/development/forgejo-runner-secret.yaml
+++ b/services/development/forgejo-runner-secret.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/secret.json
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: forgejo-runner-registration
+  namespace: forgejo-runner
+stringData:
+  uuid: ${FORGEJO_RUNNER_UUID}
+  token: ${FORGEJO_RUNNER_TOKEN}

--- a/services/development/forgejo-runner.yaml
+++ b/services/development/forgejo-runner.yaml
@@ -1,0 +1,85 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/namespace.json
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forgejo-runner
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo-runner
+  namespace: forgejo-runner
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: forgejo-runner
+    namespace: flux-system
+  values:
+    forgejo:
+      url: http://forgejo-http.development.svc.cluster.local:3000
+      existingSecret: forgejo-runner-registration
+
+    image:
+      repository: registry.erwanleboucher.dev/eleboucher/runner
+      tag: 12.13.0
+
+    runnerConfig: |
+      cache:
+        enabled: true
+        dir: /data/cache
+        port: 8088
+        proxy_port: 8089
+      container:
+        docker_host: "-"
+        workdir_parent: shared/workdir
+      host:
+        workdir_parent: /data/act
+      log:
+        level: info
+      plugins:
+        k8s:
+          address: "unix:///plugin/forgejo-runner-k8s.sock"
+          options:
+            namespace: forgejo-runner
+            poll_timeout: 10m
+            labels: "app.kubernetes.io/name=forgejo-runner-instance,app.kubernetes.io/instance=env-${ENV_ID}"
+            resources: |
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+      runner:
+        capacity: 2
+        labels:
+          - ubuntu-latest:k8s:/config/podspec-default.yaml
+          - default:k8s:/config/podspec-default.yaml
+        timeout: 3h
+        shutdown_timeout: 3m
+
+    podSpecs:
+      podspec-default.yaml: |-
+        containers:
+          - name: main
+            image: ghcr.io/bjw-s-labs/forgejo-runner:ubuntu-24.04@sha256:fea96a5b525857bee41cc132cf95df67191b73cdd681569ada3000111420397e
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: DEBIAN_FRONTEND
+                value: noninteractive
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+        restartPolicy: Never
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 1Gi

--- a/services/development/forgejo.yaml
+++ b/services/development/forgejo.yaml
@@ -4,6 +4,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: forgejo
+  namespace: development
 spec:
   interval: 12h
   layerSelector:
@@ -18,6 +19,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: forgejo-data
+  namespace: development
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: longhorn
@@ -30,6 +32,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: &name forgejo
+  namespace: development
 spec:
   interval: 1h
   chartRef:

--- a/services/development/kustomization.yaml
+++ b/services/development/kustomization.yaml
@@ -2,7 +2,9 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: development
 resources:
 - namespace.yaml
 - forgejo.yaml
+- forgejo-runner.yaml
+- forgejo-runner-secret.yaml
+- forgejo-runner-repo.yaml


### PR DESCRIPTION
Adds a Forgejo Actions runner so repos on the Forgejo instance can run CI (`.forgejo/workflows`).

## Design

- **Dedicated namespace** `forgejo-runner` for the runner deployment and all CI job pods — full isolation from other workloads.
- Chart: [`forgejo-runner`](https://github.com/eleboucher/runner-k8s-plugin) v12.10.9 via OCIRepository. The chart runs the Forgejo runner plus its native Kubernetes backend plugin as a native sidecar (`restartPolicy: Always`, requires k8s ≥1.29; cluster is on 1.36).
- **No DinD, no privileged pods.** Job steps run in ephemeral, non-root job pods created by the plugin through an in-cluster ServiceAccount whose Role is limited to jobs/pods operations inside the runner namespace only.
- Runner registration uses the existing Forgejo UI registration values from `cluster-secrets` (`FORGEJO_RUNNER_UUID`, `FORGEJO_RUNNER_TOKEN`) substituted into a namespaced Secret — same `${VAR}` pattern as other Secrets in the repo.
- Labels registered with workflows: `ubuntu-latest` and `default`, backed by a digest-pinned `ghcr.io/bjw-s-labs/forgejo-runner:ubuntu-24.04` podspec with cpu/memory requests+limits and capacity of 2 concurrent jobs.
- No HTTPRoute needed — the runner only makes outbound connections.

## Notes

- The forgejo-runner chart/repo is Renovate-friendly via the existing flux manager patterns (OCIRepository tag + image tags in HelmRelease).
- After merge: `flux reconcile kustomization services-development --with-source`, then check the runner appears under Site Administration → Actions → Runners and trigger a test workflow with `runs-on: ubuntu-latest`.
