### PR TITLE
feat(forgejo-runner): add kaniko podspec label for unprivileged image builds

### DIFF
--- a/services/development/forgejo-runner.yaml
+++ b/services/development/forgejo-runner.yaml
@@ -57,10 +57,16 @@ spec:
         labels:
           - ubuntu-latest:k8s:/config/podspec-default.yaml
           - default:k8s:/config/podspec-default.yaml
+
           # Image builds: job runs inside a privileged buildah image
           # (overlay storage + user namespaces need it on k0s). Opt in
           # per-workflow with runs-on: buildah.
           - buildah:k8s:/config/podspec-buildah.yaml
+
+          # Image builds (unprivileged): kaniko executor debug image. Opt in
+          # per-workflow with runs-on: kaniko. No daemon, no host privileges —
+          # build via /kaniko/executor --dockerfile ... --destination ...
+          - kaniko:k8s:/config/podspec-kaniko.yaml
         timeout: 3h
         shutdown_timeout: 3m
 
@@ -91,6 +97,23 @@ spec:
             env:
               - name: BUILDAH_ISOLATION
                 value: chroot
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+        restartPolicy: Never
+
+      podspec-kaniko.yaml: |-
+        containers:
+          - name: main
+            image: gcr.io/kaniko-project/executor:v1.24.0-debug@sha256:2562c4fe551399514277ffff7dcca9a3b1628c4ea38cb017d7286dc6ea52f4cd
+            imagePullPolicy: IfNotPresent
+            command: ["/busybox/sleep", "infinity"]
+            env:
+              - name: DOCKER_CONFIG
+                value: /kaniko/.docker
             resources:
               requests:
                 cpu: 250m


### PR DESCRIPTION
Add a `kaniko` runner label alongside `buildah` for image builds in job pods.

- Podspec: `gcr.io/kaniko-project/executor:v1.24.0-debug` (digest-pinned). The `-debug` variant ships a busybox shell so workflow steps can run, with the entrypoint overridden to keep the pod alive while `/kaniko/executor` is invoked per-step.
- Unprivileged: no `privileged: true`, no daemon - kaniko builds entirely in userspace, so this label works where the buildah label's privileged pod is not acceptable.
- Usage: `runs-on: kaniko`, then `/kaniko/executor --dockerfile Dockerfile --destination <registry/repo:tag> --context $GITHUB_WORKSPACE`. Registry auth goes in `/kaniko/.docker/config.json` (DOCKER_CONFIG is preset) or via executor credential flags.

Note: kaniko upstream is stale; the Chainguard fork (chainguard-dev/kaniko) is the maintained continuation if we ever need to move off gcr.io images.