### PR TITLE
feat(development): pin forgejo image tag+digest in HelmRelease

### DIFF
--- a/services/development/forgejo.yaml
+++ b/services/development/forgejo.yaml
@@ -39,6 +39,10 @@ spec:
     kind: OCIRepository
     name: forgejo
   values:
+    image:
+      repository: code.forgejo.org/forgejo/forgejo
+      tag: 15.0.7-rootless@sha256:1131f4c646d6115577b7cb9ccfe8cd2c289bb54a1e1ed42400be0e22916af924
+
     valkey-cluster:
       enabled: false
     valkey:


### PR DESCRIPTION
Pin the forgejo app image to the currently-running version (tag + digest) in the HelmRelease values so a chart bump alone can't silently change the app image. Renovate will manage the pin going forward.

The forgejo-runner HelmRelease already pins its image (tag@digest), so no change needed there.