### PR TITLE
feat(cluster): expose etcd metrics listener on :2381

### DIFF
--- a/config/cluster.yaml
+++ b/config/cluster.yaml
@@ -20,6 +20,19 @@ spec:
           nodeLocalLoadBalancing:
             enabled: true
             type: EnvoyProxy
+        storage:
+          etcd:
+            # Expose etcd's metrics on a dedicated plaintext HTTP listener so
+            # Prometheus can scrape server-side etcd metrics without an mTLS
+            # client secret. This is etcd's documented best practice for
+            # monitoring (keeps scrapes off the client 2379 / peer 2380 ports).
+            #
+            # Requires one `k0sctl apply` (rolling controller restart, one node
+            # at a time — 3-member quorum holds with 2). Prometheus-side, the
+            # matching scrape config is in platform/monitoring/prometheus-stack.yaml.
+            extraArgs:
+              # k0s etcd.extraArgs is a map of key-values (k0s docs: spec.storage.etcd.extraArgs)
+              listen-metrics-urls: http://0.0.0.0:2381
   hosts:
     - hostname: k0s-inwin-01
       role: controller+worker


### PR DESCRIPTION
## Summary

Adds `spec.storage.etcd.extraArgs.listen-metrics-urls: http://0.0.0.0:2381` to the k0sctl cluster config. This gives etcd a dedicated plaintext HTTP metrics/health listener — etcd's documented best practice for monitoring — so Prometheus can scrape server-side etcd metrics (`etcd_disk_wal_fsync_duration_seconds`, `etcd_server_leader_changes_seen_total`, `etcd_mvcc_db_total_size_in_bytes`, ...) with **no client secret and no TLS**.

## Context

The etcd metrics investigation (2026-09-09) found the k0s-inwin-03 member stalling with etcd get/list/update p99 pinned at ~4.6s (timeout-bound) while its siblings sit at 9–290ms. The one metric that would directly confirm the stall mechanism (WAL fsync) isn't scraped today.

Two paths were identified:
- **PR #3349** — scrape the peer port (2380) with an mTLS client Secret. Works today, no k0s lifecycle change.
- **This PR** — add a plaintext metrics listener (2381). No secret, no `insecureSkipVerify`, but requires one `k0sctl apply`.

## Apply / rollout

```sh
k0sctl apply --config config/cluster.yaml
```

k0sctl performs a rolling controller restart, one node at a time; the 3-member quorum holds with 2, so the API stays up throughout. Verify after rollout:

```sh
curl -s http://10.72.13.11:2381/metrics | head   # repeat for .12 / .13
```

## Follow-up (after this is rolled out)

Simplify PR #3349's ServiceMonitor: switch to `scheme: http`, port 2381, drop the `kube-etcd-client` Secret mount and `insecureSkipVerify`. The alert rules in #3349 apply unchanged.

## Schema note

Per k0s docs, `spec.storage.etcd.extraArgs` is a **map of key-values** (not a list) — initial commit of this branch had it as a list; corrected before review.