### PR TITLE
feat(velero): switch daily backups to incremental fsBackup, split critical CSI schedule

### DIFF
--- a/platform/velero/helmrelease.yaml
+++ b/platform/velero/helmrelease.yaml
@@ -132,14 +132,74 @@ spec:
 
     # Backup schedules (managed by the chart).
     #
-    # Two daily schedules + one weekly:
-    #   daily-infra — stateless infrastructure (manifests only)
-    #   daily       — everything non-system, with CSI snapshots → B2
-    #   weekly      — everything non-system, 90d retention, no snapshots
+    # Three daily schedules + one weekly:
+    #   daily          — everything non-system, Kopia filesystem backup
+    #                    (incremental, deltas only) → B2
+    #   daily-critical — database namespaces, CSI snapshots + data movement
+    #                    → B2 (crash-consistent block backups for the small
+    #                    set of volumes that need them)
+    #   daily-infra    — stateless infrastructure (manifests only)
+    #   weekly         — everything non-system, 90d retention, no snapshots
     #
     # New namespaces are auto-included in daily/weekly via wildcard + exclusions.
-    # The only list to maintain is daily-infra (10 namespaces, changes rarely).
+    # The only lists to maintain are daily-infra and daily-critical.
+    #
+    # Why daily uses fsBackup instead of CSI snapshotMoveData: the CSI path
+    # creates a trampoline PVC per volume (full Longhorn reclone) and serial
+    # uploads that run for hours, saturating node disk I/O (measured 8s write
+    # latencies, load 80+) and starving other workloads on the node. Kopia
+    # fsBackup reads only dirty files after the first run and typically
+    # finishes in minutes.
     schedules:
+      # Databases and other block-level-critical volumes. CSI snapshot + data
+      # movement gives crash-consistent block backups; kept to a small,
+      # explicit list so the reclone I/O storm stays bounded.
+      daily-critical:
+        disabled: false
+        schedule: "0 0 * * *"
+        useOwnerReferencesInBackup: true
+        template:
+          ttl: 720h0m0s           # 30 days
+          includedNamespaces:
+            - database
+          snapshotVolumes: true
+          defaultVolumesToFsBackup: false
+          snapshotMoveData: true
+          resourcePolicy:
+            kind: configmap
+            name: velero-volume-policy
+          metadata:
+            labels:
+              backup-tier: daily-critical
+      # Everything non-system via Kopia filesystem backup (incremental).
+      # New namespaces are auto-included via wildcard — nothing to update.
+      # The velero-volume-policy ConfigMap skips NFS-backed volumes (media-pool,
+      # nvr-pool, photos-pool) so only Longhorn-backed PVCs get backed up.
+      daily:
+        disabled: false
+        schedule: "30 0 * * *"    # staggered after daily-critical
+        useOwnerReferencesInBackup: true
+        template:
+          ttl: 720h0m0s           # 30 days
+          includedNamespaces:
+            - "*"
+          excludedNamespaces:
+            - kube-system
+            - kube-public
+            - kube-node-lease
+            - flux-system
+            - velero
+            - longhorn-system
+            # CSI snapshot path lives in daily-critical; exclude here to
+            # avoid double-backing the database volumes.
+            - database
+          snapshotVolumes: false
+          # Node-agent Kopia incremental backup of PVC filesystems → B2.
+          # Only changed files upload after the first run.
+          defaultVolumesToFsBackup: true
+          metadata:
+            labels:
+              backup-tier: daily
       # Infrastructure namespaces — cluster-level services that are Flux-managed
       # and stateless. Resource manifests only; no PVC data worth snapshotting.
       daily-infra:
@@ -164,38 +224,6 @@ spec:
           metadata:
             labels:
               backup-tier: daily-infra
-      # Everything non-system, with CSI snapshots + data movement to B2.
-      # New namespaces are auto-included via wildcard — nothing to update.
-      # The velero-volume-policy ConfigMap skips NFS-backed volumes (media-pool,
-      # photos-pool) so only Longhorn CSI PVCs get snapshotted.
-      daily:
-        disabled: false
-        schedule: "0 0 * * *"
-        useOwnerReferencesInBackup: true
-        template:
-          ttl: 720h0m0s           # 30 days
-          includedNamespaces:
-            - "*"
-          excludedNamespaces:
-            - kube-system
-            - kube-public
-            - kube-node-lease
-            - flux-system
-            - velero
-            - longhorn-system
-          snapshotVolumes: true
-          defaultVolumesToFsBackup: false
-          # Take a CSI (Longhorn) snapshot, then move the data off-cluster to
-          # B2 via the node-agent (Kopia). Requires the longhorn-velero
-          # VolumeSnapshotClass (volumesnapshotclass.yaml). Without this the
-          # snapshot would stay in-cluster only and never reach B2.
-          snapshotMoveData: true
-          resourcePolicy:
-            kind: configmap
-            name: velero-volume-policy
-          metadata:
-            labels:
-              backup-tier: daily
       # Weekly catch-all for extended retention — same scope as daily, no
       # snapshots, kept 90 days.
       weekly:

--- a/services/automation/hermes-agent.yaml
+++ b/services/automation/hermes-agent.yaml
@@ -207,8 +207,8 @@ spec:
           path: /health
           port: api-server
         periodSeconds: 30
-        timeoutSeconds: 5
-        failureThreshold: 3
+        timeoutSeconds: 15
+        failureThreshold: 5
       readiness:
         httpGet:
           path: /health


### PR DESCRIPTION
## Problem

The `daily` backup schedule (`snapshotMoveData: true` on every Longhorn PVC) creates a trampoline PVC per volume — a full Longhorn reclone — then uploads each serially to B2. Last night's run was still churning data-mover pods **5+ hours** after the 00:00 UTC start. During that window the affected node measured **load 82, 100% CPU, and 8-second disk write latencies** (vs. a 2.0 load / 44ms baseline an hour earlier), which starved co-located workloads — including the hermes-agent gateway, whose 15-second liveness budget was exceeded, causing repeated container restarts.

## Change

**Backup restructure** (`platform/velero/helmrelease.yaml`):

- `daily` now uses **Kopia filesystem backup** (`defaultVolumesToFsBackup: true`): the node-agent reads PVC filesystems directly and uploads incremental deltas only. First run is a full copy; subsequent nightly runs typically transfer only changed files and finish in minutes. No trampoline PVC, no Longhorn reclone, no I/O storm.
- New `daily-critical` schedule keeps the CSI snapshot + data movement path for the `database` namespace only (Kafka brokers, Postgres) — a small, bounded set of volumes where crash-consistent block backups are worth the reclone cost.
- `daily` is staggered 30 minutes after `daily-critical` and excludes `database` to avoid double-backing those volumes.
- `daily-infra` and `weekly` are unchanged.

**Gateway resilience** (`services/automation/hermes-agent.yaml`):

- Liveness probe tolerance widened from 3×5s to 5×15s so a transient node I/O stall can no longer kill the container.

## Verification

- `kubectl kustomize platform/velero/` renders cleanly; all four schedules present with expected flags.
- First `daily` fsBackup run will be a full upload; expect subsequent runs to be incremental and short. Watch `velero_backup_tarball_size_bytes` and data-mover pod count the next morning.